### PR TITLE
Chore/Refactor Navbar - [#107960374]

### DIFF
--- a/app/assets/javascripts/AngularConfig.js.coffee
+++ b/app/assets/javascripts/AngularConfig.js.coffee
@@ -20,40 +20,62 @@ angular.module('dahlia.controllers',[])
 # might seem somewhat awkward, but it will make more sense as we add more routes to our application
 @dahlia.config ['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterProvider) ->
   $stateProvider
-    .state('listings', {
-      url: '/listings',
-      templateUrl: 'listings/templates/listings.html'
-      controller: 'ListingController',
+    .state('dahlia', {
+      url: ''
+      abstract: true
+      views:
+        'nav@':
+          templateUrl: 'shared/templates/nav.html'
+          controller: 'NavController'
+    })
+    .state('dahlia.listings', {
+      url: '/listings'
+      views:
+        'container@':
+          templateUrl: 'listings/templates/listings.html'
+          controller: 'ListingController'
       resolve:
         listings: ['$stateParams', 'ListingService', ($stateParams, ListingService) ->
           ListingService.getFavorites()
           ListingService.getListings()
         ]
-    }).state('listing', {
+    })
+    .state('dahlia.listing', {
       url: '/listings/:id',
-      templateUrl: 'listings/templates/listing.html'
-      controller: 'ListingController',
+      views:
+        'container@':
+          templateUrl: 'listings/templates/listing.html'
+          controller: 'ListingController'
       resolve:
         listing: ['$stateParams', 'ListingService', ($stateParams, ListingService) ->
           ListingService.getFavorites()
           ListingService.getListing($stateParams.id)
         ]
-    }).state('favorites', {
-      url: '/favorites',
-      templateUrl: 'listings/templates/favorites.html'
-      controller: 'ListingController',
+    })
+    .state('dahlia.favorites', {
+      url: '/favorites'
+      views:
+        'container@':
+          templateUrl: 'listings/templates/favorites.html'
+          controller: 'ListingController'
       resolve:
         listing: ['$stateParams', 'ListingService', ($stateParams, ListingService) ->
           ListingService.getFavorites()
           ListingService.getFavoriteListings()
         ]
-    }).state('welcome', {
-      url: '/',
-      templateUrl: 'pages/templates/welcome.html'
-    }).state('share', {
-      url: '/share/:id',
-      templateUrl: 'pages/templates/share.html'
-      controller: 'ShareController'
+    })
+    .state('dahlia.welcome', {
+      url: '/'
+      views:
+        'container@':
+          templateUrl: 'pages/templates/welcome.html'
+    })
+    .state('dahlia.share', {
+      url: '/share/:id'
+      views:
+        'container@':
+          templateUrl: 'pages/templates/share.html'
+          controller: 'ShareController'
     })
   $urlRouterProvider.otherwise('/') # default to welcome screen
 ]

--- a/app/assets/javascripts/listings/templates/_property-card.html.slim
+++ b/app/assets/javascripts/listings/templates/_property-card.html.slim
@@ -15,7 +15,7 @@
   header.property-card_content
     hgroup.property-card_info
       h1.property-card_title.gamma
-        a ui-sref="listing({id: listing.id})"
+        a ui-sref="dahlia.listing({id: listing.id})"
           | {{listing.name}}
 
       p
@@ -25,12 +25,12 @@
       p
         | Application Due {{listing.application_due_date | dateSuffix}}
       .property-card_action
-        a.button.tiny.secondary ui-sref="listing({id: listing.id})"
+        a.button.tiny.secondary ui-sref="dahlia.listing({id: listing.id})"
           | See Details
     .property-card_stats.show-for-medium-up
       .stats-card.bottom.bg-mist
         ng-include src="'listings/templates/_stats-list.html'"
-    button.button.small.secondary ng-show="shared.showSharing()" ui-sref="share({id: listing.id})"
+    button.button.small.secondary ng-show="shared.showSharing()" ui-sref="dahlia.share({id: listing.id})"
       | Share Property
 
     ul.button-group ng-show="shared.showSocial()"

--- a/app/assets/javascripts/listings/templates/favorites.html.slim
+++ b/app/assets/javascripts/listings/templates/favorites.html.slim
@@ -1,5 +1,3 @@
-ng-include src="'shared/templates/nav.html'"
-
 ul.padding-top--2x
   li.margin-bottom--2x ng-repeat="listing in listings"
     ng-include src="'listings/templates/_property-card.html'" ng-show="isFavorited(listing.id)"

--- a/app/assets/javascripts/listings/templates/listing.html.slim
+++ b/app/assets/javascripts/listings/templates/listing.html.slim
@@ -1,5 +1,3 @@
-ng-include src="'shared/templates/nav.html'"
-
 div.property-hero
   figure.property-hero_figure
     div.p-relative
@@ -65,5 +63,5 @@ div.property-hero
       | {{listing.application_info.property_manager_phone}}
 
   div.property-hero_action.text-center
-    a.button.small.secondary ui-sref="share({id: listing.id})"
+    a.button.small.secondary ui-sref="dahlia.share({id: listing.id})"
       | Share Property

--- a/app/assets/javascripts/listings/templates/listings.html.slim
+++ b/app/assets/javascripts/listings/templates/listings.html.slim
@@ -1,5 +1,3 @@
-ng-include src="'shared/templates/nav.html'"
-
 ul.padding-top--2x
   li.margin-bottom--2x ng-repeat="listing in listings"
     ng-include src="'listings/templates/_property-card.html'"

--- a/app/assets/javascripts/pages/templates/share.html.slim
+++ b/app/assets/javascripts/pages/templates/share.html.slim
@@ -1,5 +1,3 @@
-ng-include src="'shared/templates/nav.html'"
-
 header.header-block
   a.button.tiny(back-button)
     | < Back

--- a/app/assets/javascripts/pages/templates/welcome.html.slim
+++ b/app/assets/javascripts/pages/templates/welcome.html.slim
@@ -1,11 +1,9 @@
-ng-include src="'shared/templates/nav.html'"
-
 .page.padding--2x
   header.block.bg-mist.text-center
     h1 Welcome to the SF DAHLIA Housing Portal
   .block.text-center
     h2.gamma Browse currently available BMR rental properties
-    a.button.radius href="#/listings" See Properties
+    a.button.radius ui-sref="dahlia.listings" See Properties
   section.language-actions
     ul.button-group.even-3
       li

--- a/app/assets/javascripts/shared/NavController.js.coffee
+++ b/app/assets/javascripts/shared/NavController.js.coffee
@@ -1,0 +1,24 @@
+############################################################################################
+###################################### CONTROLLER ##########################################
+############################################################################################
+
+NavController = ($scope, $state) ->
+
+  $scope.showListingsNav = () ->
+    ["dahlia.favorites", "dahlia.listing", "dahlia.share"].indexOf($state.current.name) > -1
+
+  $scope.showFavoritesNav = () ->
+    $state.current.name == "dahlia.listings"
+
+  $scope.showSocial = () ->
+    $state.current.name == "dahlia.favorites"
+
+############################################################################################
+######################################## CONFIG ############################################
+############################################################################################
+
+NavController.$inject = ['$scope', '$state']
+
+angular
+  .module('dahlia.controllers')
+  .controller('NavController', NavController)

--- a/app/assets/javascripts/shared/SharedService.js.coffee
+++ b/app/assets/javascripts/shared/SharedService.js.coffee
@@ -5,15 +5,6 @@
 SharedService = ($http, $state) ->
   Service = {}
 
-  Service.showListingsNav = () ->
-    ["favorites", "listing", "share"].indexOf($state.current.name) > -1
-
-  Service.showFavoritesNav = () ->
-    $state.current.name == "listings"
-
-  Service.showSocial = () ->
-    $state.current.name == "favorites"
-
   return Service
 
 

--- a/app/assets/javascripts/shared/templates/nav.html.slim
+++ b/app/assets/javascripts/shared/templates/nav.html.slim
@@ -2,23 +2,23 @@ nav.top-bar role="navigation"
   ul.title-area
     li.name
       h1
-        a ui-sref="welcome" SF DAHLIA Housing
-    li ng-show="shared.showListingsNav()" class="toggle-topbar"
-      a ui-sref="listings"
+        a ui-sref="dahlia.welcome" SF DAHLIA Housing {{state}}
+    li ng-show="showListingsNav()" class="toggle-topbar"
+      a ui-sref="dahlia.listings"
         span class="ui-icon"
           svg
             use xlink:href="#i-search"
-    li ng-show="shared.showFavoritesNav()" class="toggle-topbar"
-      a ui-sref="favorites"
+    li ng-show="showFavoritesNav()" class="toggle-topbar"
+      a ui-sref="dahlia.favorites"
         span class="ui-icon"
           svg
             use xlink:href="#i-like-fill"
 
   section class="top-bar-section"
     ul class="right"
-      li ng-show="shared.showListingsNav()"
-        a ui-sref="listings"
+      li ng-show="showListingsNav()"
+        a ui-sref="dahlia.listings"
           | Listings
-      li ng-show="shared.showFavoritesNav()"
-        a ui-sref="favorites"
+      li ng-show="showFavoritesNav()"
+        a ui-sref="dahlia.favorites"
           | My Favorites

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,8 +8,8 @@ html lang="en"
     = csrf_meta_tags
 
   body ng-app="dahlia" id="ng-app"
-
-    ui-view
+    div(ui-view="nav")
+    div(ui-view="container")
 
     / icon collection
     ng-include src="'shared/templates/icons.html'"


### PR DESCRIPTION
Refactored navbar to not have to be included on every page, moved its logic to its own controller (out of SharedService). 

However now all the route names are prefaced with "dahlia." like "dahlia.welcome". We could use "app" there or any default name, but "dahlia" seemed in line with how we're prefixing other angular components. See here (towards the bottom of the page) for the pattern I used to set up the header -- @menslow would be good to get your take on it: http://www.funnyant.com/angularjs-ui-router/ 