### PR TITLE
Feature/eligibility estimator #107526496

### DIFF
--- a/app/assets/javascripts/AngularConfig.js.coffee
+++ b/app/assets/javascripts/AngularConfig.js.coffee
@@ -77,6 +77,13 @@ angular.module('dahlia.controllers',[])
           templateUrl: 'pages/templates/share.html'
           controller: 'ShareController'
     })
+    .state('dahlia.eligibility-estimator', {
+      url: '/eligibility-estimator'
+      views:
+        'container@':
+          templateUrl: 'pages/templates/eligibility-estimator.html'
+          controller: 'EligibilityEstimatorController'
+    })
   $urlRouterProvider.otherwise('/') # default to welcome screen
 ]
 

--- a/app/assets/javascripts/listings/templates/listings.html.slim
+++ b/app/assets/javascripts/listings/templates/listings.html.slim
@@ -1,3 +1,8 @@
+section.sub-bar.bg-mist
+  .row
+    h3.sub-bar_header.epsilon Estimate Eligibility
+    a.button--start.button.tiny Get Started
+
 ul.padding-top--2x
   li.margin-bottom--2x ng-repeat="listing in listings"
     ng-include src="'listings/templates/_property-card.html'"

--- a/app/assets/javascripts/listings/templates/listings.html.slim
+++ b/app/assets/javascripts/listings/templates/listings.html.slim
@@ -1,7 +1,9 @@
 section.sub-bar.bg-mist
   .row
-    h3.sub-bar_header.epsilon Estimate Eligibility
-    a.button--start.button.tiny Get Started
+    h3.sub-bar_header.epsilon
+      | Estimate Eligibility
+    a.button--start.button.tiny ui-sref="dahlia.eligibility-estimator"
+      | Get Started
 
 ul.padding-top--2x
   li.margin-bottom--2x ng-repeat="listing in listings"

--- a/app/assets/javascripts/pages/EligibilityEstimatorController.js.coffee
+++ b/app/assets/javascripts/pages/EligibilityEstimatorController.js.coffee
@@ -1,0 +1,46 @@
+############################################################################################
+###################################### CONTROLLER ##########################################
+############################################################################################
+
+EligibilityEstimatorController = ($scope, $state) ->
+  formDefaults =
+    'household_size': ''
+    'income_timeframe': ''
+    'income_total': ''
+
+  # hideAlert tracks if the user has manually closed the alert "X"
+  $scope.hideAlert = false
+
+  $scope.submitForm = () ->
+    # for now, this doesn't actually "submit", it just clears the form
+    if ($scope.eligibilityForm.$valid)
+      # submit
+      console.log 'Submitted!'
+    else
+      $scope.hideAlert = false
+
+  $scope.clearForm = ->
+    $scope.eligibilityForm.$setUntouched()
+    $scope.eligibilityForm.$setPristine()
+    $scope.hideAlert = false
+    $scope.filters = angular.copy(formDefaults)
+
+  $scope.inputInvalid = (name) ->
+    form = $scope.eligibilityForm
+    form[name].$invalid && (form[name].$touched || form.$submitted)
+
+  $scope.showAlert = ->
+    form = $scope.eligibilityForm
+    # show alert if we've submitted an invalid form, and we haven't manually hidden it
+    form.$submitted && form.$invalid && $scope.hideAlert == false
+
+
+############################################################################################
+######################################## CONFIG ############################################
+############################################################################################
+
+EligibilityEstimatorController.$inject = ['$scope', '$state']
+
+angular
+  .module('dahlia.controllers')
+  .controller('EligibilityEstimatorController', EligibilityEstimatorController)

--- a/app/assets/javascripts/pages/templates/eligibility-estimator.html.slim
+++ b/app/assets/javascripts/pages/templates/eligibility-estimator.html.slim
@@ -1,8 +1,7 @@
 section.sub-bar.bg-mist
   .row
     h3.sub-bar_header.epsilon Estimate Eligibility
-    a.button.tiny ng-show="eligibilityForm.$pristine"
-      / currently non-functional per the story -- could link back to listings?
+    a.button.tiny ui-sref="dahlia.listings" ng-show="eligibilityForm.$pristine"
       | Cancel
     a.button.tiny ng-click="clearForm()" ng-show="!eligibilityForm.$pristine"
       | Clear Filters

--- a/app/assets/javascripts/pages/templates/eligibility-estimator.html.slim
+++ b/app/assets/javascripts/pages/templates/eligibility-estimator.html.slim
@@ -1,0 +1,75 @@
+section.sub-bar.bg-mist
+  .row
+    h3.sub-bar_header.epsilon Estimate Eligibility
+    a.button.tiny ng-show="eligibilityForm.$pristine"
+      / currently non-functional per the story -- could link back to listings?
+      | Cancel
+    a.button.tiny ng-click="clearForm()" ng-show="!eligibilityForm.$pristine"
+      | Clear Filters
+
+section.row
+  .medium-8.columns
+    .alert-box.alert.margin-top alert="" close="hideAlert = true" ng-show="showAlert()"
+      | You'll need to resolve any errors before moving on.
+
+    form.padding-top name="eligibilityForm" ng-submit="submitForm()" novalidate=""
+      .row
+        .medium-12.columns.margin-bottom
+          h3.t-sans.gamma
+            | First we'll ask you about the number of people in your household.
+          label.p-relative ng-class="{ error: inputInvalid('household_size') }"
+            span.eligibility-form_header Household Size
+            span.has-tip.a-top-right tooltip="Household is defined as anyone living with you in the residence, including spouse, roommates, parents and children over 6 years old" tooltip-trigger="click" tooltip-placement="left" aria-haspopup="true"
+              span.ui-icon.ui-medium.i-primary
+                svg
+                  use xlink:href="#i-info"
+            select name="household_size" ng-model="filters.household_size" required=""
+              option value="" How many people are you applying to live with?
+              option value="1" 1 person
+              option value="2" 2 people
+              option value="3" 3 people
+              option value="4" 4 people
+              option value="5" 5 people
+              option value="6" 6 people
+            small.error ng-show="inputInvalid('household_size')"
+              | Please enter a household size
+
+      .row.margin-bottom
+        .medium-12.columns.bg-mist.padding-top.padding-bottom
+          h3.t-sans.gamma
+            | Next add up your income from wages, benefits and other sources.
+          label.p-relative ng-class="{ error: inputInvalid('income_total') || inputInvalid('income_timeframe') }"
+            span.eligibility-form_header Household Income
+            input name="income_total" ng-model="filters.income_total" placeholder="Total all of your income sources" type="text" required=""
+            small.error ng-show="inputInvalid('income_total')"
+              | Please enter an income amount
+          .radio-group
+            p.d-inline-block
+              input#per_month name="income_timeframe" ng-model="filters.income_timeframe" type="radio" value="per_month" required=""
+              label for="per_month" per month
+            p.d-inline-block
+              input#per_year name="income_timeframe" ng-model="filters.income_timeframe" type="radio" value="per_year" required=""
+              label for="per_year" per year
+            small.error ng-show="inputInvalid('income_timeframe')"
+              | Please enter an income timeframe
+
+        .medium-12.columns.bg-tint.padding-top
+          p.t-tiny.margin-bottom
+            ' Note: Your total should include all income sources for each person you plan to live with over the age of 18. To help, we created a
+            a Household Income Calculator
+      .row.text-center
+        .small-12.medium-6.medium-push-6.columns
+          input.button.button.expand type="submit" value="View Matching Properties"
+        .small-12.medium-6.medium-pull-6.columns
+          a.button.button.blank.expand ng-click="clearForm()"
+            | Reset Filters
+
+
+/ -- TBD -- for another story...
+/ hr.hr-5
+/ section.row
+/   .medium-5.medium-centered.columns.text-center
+/     .notification-block.block.text-center
+/       h3 Get Notified By Email
+/       p We'll send you an email when the next property that matches you becomes available
+/       button.button.secondary.a-center Get Notified by Email

--- a/app/assets/javascripts/pages/templates/welcome.html.slim
+++ b/app/assets/javascripts/pages/templates/welcome.html.slim
@@ -1,18 +1,24 @@
 section.bg-mist
   .row
     header.hero-header.bg-mist.text-center
-      h1.hero-title Welcome to the SF DAHLIA Housing Portal
+      h1.hero-title
+        | Welcome to the SF DAHLIA Housing Portal
       .row
         .medium-8.medium-centered.columns
-          p.gamma.c-steel Enter details about household size and income and we'll highlight properties you might be eligible for
-          button.button Estimate Eligibility
+          p.gamma.c-steel
+            | Enter details about household size and income and we'll highlight properties you might be eligible for
+          a.button ui-sref="dahlia.eligibility-estimator"
+            | Estimate Eligibility
 section.row
   .medium-8.medium-centered.columns
     .block.text-center
-      p.delta Skip eligibility and browse all currently available rental properties
-      a.button.secondary ui-sref="dahlia.listings" See All Properties
+      p.delta
+        | Skip eligibility and browse all currently available rental properties
+      a.button.secondary ui-sref="dahlia.listings"
+        | See All Properties
     .text-center
-      h4.t-epsilon.t-sans.c-steel Select Language
+      h4.t-epsilon.t-sans.c-steel
+        | Select Language
       section.language-actions
         ul.button-group.even-3
           li


### PR DESCRIPTION
Functional eligibility estimator page (able to fill out form fields, and validates when fields are empty), with non-functional form submission. 

Note: currently just uses normal "select" for household size, which is how it appears in the PL, rather than the pageslide / popup panel we had discussed [+ mentioned in pivotal](https://www.pivotaltracker.com/n/projects/1405352/stories/107526496). Curious if we need it to do that additional UI -- and what about accessibility? 

a couple other things to note:
 - the (i) tooltip only looked correct if it popped "left", otherwise it was getting squished weirdly
 - it was unclear to me why the "Clear filters" button should turn into "Cancel" when the form is empty (I guess because it said "just make a non-functional button" it's unclear to me what the "eventual function" would be, which might be helpful in these cases for some context) 


