### PR TITLE
[#110105662] Removed "Resources" link from mobile nav

### DIFF
--- a/app/assets/javascripts/shared/templates/nav-mobile.html.slim
+++ b/app/assets/javascripts/shared/templates/nav-mobile.html.slim
@@ -11,6 +11,3 @@ pageslide ps-open="showNavMobile" ps-side="right" ps-size="{{ '300px' }}" ps-clo
     li
       a ui-sref="dahlia.favorites"
         | My Favorites
-    li
-      a href="#"
-        | Resources


### PR DESCRIPTION
"Resources" have been removed from the mobile nav.
