### PR TITLE
[#111989747] Updated Additional Rules section to include live Salesfo…

### DIFF
--- a/app/assets/javascripts/listings/templates/listing/_eligibility.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_eligibility.html.slim
@@ -94,26 +94,29 @@ accordion-heading.lead
       p.t-small.c-steel
         | Section 8 housing vouchers and other valid rental assistance programs can be used for this property.
       p.t-small.c-steel In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-  .content-panel.wide
+  .content-panel.wide ng-if="listing.Credit_Rating || listing.Eviction_History || listing.Criminal_History"
     header.margin-bottom
       h4.t-epsilon.t-sans.margin-bottom--half Additional Eligibility Rules
       p.t-small.c-steel Applicants must also qualify under the rules of the building.
     accordion.accordion-nested.accordion.trigger-left
-      accordion-group.accordion-navigation
+      accordion-group.accordion-navigation ng-if="listing.Credit_Rating"
         accordion-heading.accordion-header
           | Credit Rating
           ng-include src="'shared/templates/_arrow-down.html'"
         #panel2a-a.content
-          p A credit report will be obtained on each applicant after their eligibility for the Inclusionary BMR program has been determined.
-      accordion-group.accordion-navigation
+          p
+            | {{listing.Credit_Rating}}
+      accordion-group.accordion-navigation ng-if="listing.Eviction_History"
         accordion-heading.accordion-header
           | Renter's History
           ng-include src="'shared/templates/_arrow-down.html'"
         #panel2a-b.content
-          p Applicants with an eviction by a previous landlord, for cause, within the last 7 years will be rejected.
-      accordion-group.accordion-navigation
+          p
+            | {{listing.Eviction_History}}
+      accordion-group.accordion-navigation ng-if="listing.Criminal_History"
         accordion-heading.accordion-header
           | Criminal History
           ng-include src="'shared/templates/_arrow-down.html'"
         #panel2a-c.content
-          p Qualified applicants with criminal history will be considered for housing in compliance with Article 49 of the San Francisco Police Code, “The Fair Chance Ordinance”
+          p
+           | {{listing.Criminal_History}}


### PR DESCRIPTION
Now pulling the following fields from Salesforce:

* listing.Credit_Rating
* listing.Eviction_History
* listing.Criminal_History

Notes:

* When field is not present, accordion module does not display on page.
* When all three of these fields are not present, the entire Additional Rules section does not display on the page.

