### PR TITLE
[#112835821] Removed base url setting in order to support SVG Paths in FireFox

### DIFF
--- a/app/assets/javascripts/AngularConfig.js.coffee
+++ b/app/assets/javascripts/AngularConfig.js.coffee
@@ -181,7 +181,7 @@ angular.module('dahlia.controllers',[])
 
   # have to check if browser supports html5mode (http://stackoverflow.com/a/22771095)
   if !!(window.history && history.pushState)
-    $locationProvider.html5Mode(true)
+    $locationProvider.html5Mode({enabled: true, requireBase: false})
 ]
 
 @dahlia.config ['$httpProvider', ($httpProvider) ->

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,9 +10,6 @@ html lang="en"
     meta name="viewport" content="width=device-width, initial-scale=1"
     = csrf_meta_tags
 
-    / required for ui-router html5mode
-    base href="/"
-
   /! Google Analytics
   - if ENV['GOOGLE_ANALYTICS_KEY']
     javascript:


### PR DESCRIPTION
* Removing <base> setting and set html5mode to requireBase: False in order to fix FireFox SVG icon path issue.