### PR TITLE
Git clean branches

### DIFF
--- a/bin/git-clean-branches
+++ b/bin/git-clean-branches
@@ -1,0 +1,2 @@
+#!/bin/sh
+git branch --merged master | grep -v "\* master" | xargs -n 1 git branch -d

--- a/bin/git-clean-branches
+++ b/bin/git-clean-branches
@@ -1,2 +1,2 @@
 #!/bin/sh
-git branch --merged master | grep -v "\* master" | xargs -n 1 git branch -d
+git branch --merged master | egrep -v 'master|demo|staging|production' | xargs -n 1 git branch -d


### PR DESCRIPTION
This is just a quick fix thing that I found to be useful. Ever get annoyed that you have a bunch of stale branches checked out locally that have since been merged to master?

for example:
```
➜  sf-dahlia-web git:(master) ✗ git branch
  bugs/chinese-language-characters-#113003861
  bugs/empty-favorites-#113097901
  bugs/salesforce-service-error-#112868245
  bugs/under-six-filter-#112837033
  chores/add-tests-to-listing-service-#113043369
  chores/eligibility-tests-#113043353
  chores/modal-instance-controller-test-#113043431
  features/additional-fees-update-#112634271
  features/additional-housing-opportunities-#112549983
  features/ami-text-on-income-calculator-#107840704
  features/lottery-date-in-sidebar-#112950101
  features/rename-additional-building-rules-sections-#113378971
  features/what-to-expect-sidebar-#112633065
* master
  production
```

Now you can run `bin/git-clean-branches` and it will delete all of your local branches that are already merged with `master`:
```
Deleted branch bugs/chinese-language-characters-#113003861 (was b324644).
Deleted branch bugs/empty-favorites-#113097901 (was f993ba9).
Deleted branch bugs/salesforce-service-error-#112868245 (was 20ef227).
Deleted branch bugs/under-six-filter-#112837033 (was 00c5644).
Deleted branch chores/eligibility-tests-#113043353 (was 652c673).
Deleted branch features/additional-fees-update-#112634271 (was 6bf88d5).
Deleted branch features/additional-housing-opportunities-#112549983 (was b996c44).
Deleted branch features/lottery-date-in-sidebar-#112950101 (was 993fed4).
Deleted branch features/rename-additional-building-rules-sections-#113378971 (was 08d3e51).
Deleted branch features/what-to-expect-sidebar-#112633065 (was e224946).
``` 

To go one step further, you can add an "alias" to your `.git/config` like so:
```bash
[alias]
	clean-branches = git-clean-branches
```

And that will allow you to run `git clean-branches`, or whatever you want to rename your alias, could be `cb`, `cleanup`, etc. (note `git clean` is already taken)  instead of the more verbose `bin/git-clean-branches`.



