### PR TITLE
hotfix - redisplay lotteryNumber on confirmation page

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -71,6 +71,7 @@ class Api::V1::ShortFormController < ApiController
       if current_user && application_complete
         delete_draft_application(application_params[:listingID])
       end
+      render json: response
     else
       render json: { error: ShortFormService.error }, status: 422
     end


### PR DESCRIPTION
quick fix to re-display lottery number on short form confirmation page