### PR TITLE
[#127514293] - updates to better handle signing out

### DIFF
--- a/app/assets/javascripts/account/AccountService.js.coffee
+++ b/app/assets/javascripts/account/AccountService.js.coffee
@@ -101,15 +101,10 @@ AccountService = ($state, $auth, $modal, $http, $translate, ShortFormApplication
       Service.accountError.messages.password = msg
 
   Service.signOut = ->
+    # reset the user data immediately, then call signOut
+    angular.copy({}, Service.loggedInUser)
+    ShortFormApplicationService.resetUserData()
     $auth.signOut()
-      .then((response) ->
-        angular.copy({}, Service.loggedInUser)
-        ShortFormApplicationService.resetUserData()
-      )
-      .catch (resp) ->
-        # still "log out" if there was some kind of error
-        angular.copy({}, Service.loggedInUser)
-        ShortFormApplicationService.resetUserData()
 
   # this gets run on init of the app in AngularConfig to check if we're logged in
   Service.validateUser = ->

--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -3,9 +3,7 @@
   ($rootScope, $state, $window, $translate, Idle, ShortFormApplicationService, AccountService, ShortFormNavigationService) ->
 
     # check if user is logged in on page load
-    AccountService.validateUser().then( ->
-      Idle.watch() if AccountService.loggedIn()
-    )
+    AccountService.validateUser()
 
     $rootScope.$on 'IdleStart', ->
       if AccountService.loggedIn()
@@ -18,7 +16,7 @@
     $rootScope.$on 'IdleTimeout', ->
       if AccountService.loggedIn()
         AccountService.signOut()
-        $state.go('dahlia.sign-in')
+        $state.go('dahlia.sign-in', {skipConfirm: true})
       else if ShortFormApplicationService.isShortFormPage($state.current)
         $state.go('dahlia.listing', {skipConfirm: true, id: ShortFormApplicationService.listing.Id})
 
@@ -73,5 +71,3 @@
         return $state.go('dahlia.welcome')
 
 ]
-
-


### PR DESCRIPTION
@chrisdolendo just noticed that it was acting a little funky on idle signout -- needed to `skipConfirm` in case you were in the middle of short form, and then also the `loggedIn()` was still returning `true` on `$stateChangeSuccess` because it hadn't given time to let the `signOut()` API call happen. However removing the user data can really happen immediately on `signOut()` since we were doing that in both cases regardless of a success/error response. 