### PR TITLE
[#132350717] - upgraded ng-file-upload package to fix the issues with…

### DIFF
--- a/app/assets/javascripts/shared/ModalInstanceController.js.coffee
+++ b/app/assets/javascripts/shared/ModalInstanceController.js.coffee
@@ -3,11 +3,6 @@ ModalInstanceController = ($scope, $modalInstance) ->
   $scope.closeModal = () ->
     $modalInstance.close()
 
-  $scope.$on '$locationChangeStart', ->
-    $modalInstance.close()
-    return
-
-
 ModalInstanceController.$inject = ['$scope', '$modalInstance']
 
 angular

--- a/app/assets/javascripts/short-form/FileUploadService.js.coffee
+++ b/app/assets/javascripts/short-form/FileUploadService.js.coffee
@@ -32,6 +32,8 @@ FileUploadService = ($http, Upload, uuid, ShortFormApplicationService) ->
     !! Service.preferences["#{fileType}_loading"]
 
   Service.uploadProof = (file, prefType, docType, listing_id) ->
+    # re-initializing Service.preferences here seems to fix some strange issues
+    Service.preferences = ShortFormApplicationService.preferences
     fileType = "#{prefType}_proof_file"
     if (!file)
       Service.preferences["#{fileType}_error"] = true

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee.erb
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee.erb
@@ -461,6 +461,10 @@ ShortFormApplicationService = (
         Service.applicant.neighborhoodPreferenceMatch = GeocodingService.neighborhoodPreferenceMatch
         Service.copyNeighborhoodMatchToHousehold()
         callback()
+      ).error( ->
+        # if there was a problem with the GeocodingService...
+        # you won't be matched to neighborhood, but at least you won't get stuck.
+        callback()
       )
     )
 

--- a/app/assets/javascripts/short-form/directives/preference-proof-uploader.html.slim
+++ b/app/assets/javascripts/short-form/directives/preference-proof-uploader.html.slim
@@ -11,7 +11,7 @@
     | {{'D2_LIVE_WORK_PREFERENCE.LETTER_FROM_EMPLOYER_INSTRUCTIONS' | translate}}
 
 .form-group.text-center ng-if="show_preference_uploader()"
-  button.button.ghost-white.expand ngf-select="uploadProof($file, preference, application.preferences[preference_proof_option])" ngf-accept="'image/jpg, image/jpeg, image/png, application/pdf'" name="file_{{preference_proof_file}}" ngf-max-size="2MB" ng-required="application.preferences[preference]" aria-describedby="{{preference_proof_file}}_error" ng-model="application.preferences[preference_proof_file]"
+  .button.ghost-white.expand ngf-select="uploadProof($file, preference, application.preferences[preference_proof_option])" ngf-accept="'image/jpg, image/jpeg, image/png, application/pdf'" name="file_{{preference_proof_file}}" ngf-max-size="2MB" ng-required="application.preferences[preference]" aria-describedby="{{preference_proof_file}}_error" ng-model="application.preferences[preference_proof_file]"
     | {{'D2_LIVE_WORK_PREFERENCE.UPLOAD_PROOF' | translate}}
   small.error id="{{preference_proof_option}}_error" ng-if="inputInvalid('file_'+preference_proof_file) && !preferenceFileError(preference_proof_file)"
     | {{'ERROR.FILE_MISSING' | translate}}

--- a/app/assets/javascripts/short-form/directives/preference-proof-uploader.html.slim
+++ b/app/assets/javascripts/short-form/directives/preference-proof-uploader.html.slim
@@ -11,7 +11,8 @@
     | {{'D2_LIVE_WORK_PREFERENCE.LETTER_FROM_EMPLOYER_INSTRUCTIONS' | translate}}
 
 .form-group.text-center ng-if="show_preference_uploader()"
-  .button.ghost-white.expand ngf-select="uploadProof($file, preference, application.preferences[preference_proof_option])" ngf-accept="'image/jpg, image/jpeg, image/png, application/pdf'" name="file_{{preference_proof_file}}" ngf-max-size="2MB" ng-required="application.preferences[preference]" aria-describedby="{{preference_proof_file}}_error" ng-model="application.preferences[preference_proof_file]"
+  / type="button" tells it not to act as a submit button
+  button.button.ghost-white.expand type="button" ngf-select="uploadProof($file, preference, application.preferences[preference_proof_option])" ngf-accept="'image/jpg, image/jpeg, image/png, application/pdf'" name="file_{{preference_proof_file}}" ngf-max-size="2MB" ng-required="application.preferences[preference]" aria-describedby="{{preference_proof_file}}_error" ng-model="application.preferences[preference_proof_file]"
     | {{'D2_LIVE_WORK_PREFERENCE.UPLOAD_PROOF' | translate}}
   small.error id="{{preference_proof_option}}_error" ng-if="inputInvalid('file_'+preference_proof_file) && !preferenceFileError(preference_proof_file)"
     | {{'ERROR.FILE_MISSING' | translate}}

--- a/app/assets/javascripts/short-form/directives/preferenceDirective.js.coffee
+++ b/app/assets/javascripts/short-form/directives/preferenceDirective.js.coffee
@@ -19,10 +19,20 @@ angular.module('dahlia.directives')
 
     scope.select_liveWork_preference = (opts = {}) ->
       scope.reset_livework_data() if opts.reset
-      preference = scope.application.preferences.liveWorkInSf_preference
-      scope.preference = preference
-      scope.setup_preference_variables(preference)
-      scope.preferences[preference] = true
+      prefs = scope.preferences
+      # have to check for the case where you had already chosen live or work (individual)
+      # but now have changed your eligibility to where you will see the liveWork combo
+      if !prefs.liveWorkInSf_preference && (prefs.liveInSf || prefs.workInSf)
+        preference = 'liveInSf' if prefs.liveInSf
+        preference = 'workInSf' if prefs.workInSf
+        prefs.liveWorkInSf_preference = preference
+        prefs.liveWorkInSf = true
+      # liveWorkInSf_preference will be 'liveInSf', 'workInSf' or undefined
+      preference = prefs.liveWorkInSf_preference
+      if preference
+        scope.preference = preference
+        scope.setup_preference_variables(preference)
+        scope.preferences[preference] = true
 
     scope.refresh_member_dropdown = ->
       oneEligibleWithHouseholdMembers = (scope.eligible_members().length == 1) && (scope._householdSize() > 1)

--- a/app/assets/javascripts/short-form/directives/preferenceDirective.js.coffee
+++ b/app/assets/javascripts/short-form/directives/preferenceDirective.js.coffee
@@ -19,20 +19,28 @@ angular.module('dahlia.directives')
 
     scope.select_liveWork_preference = (opts = {}) ->
       scope.reset_livework_data() if opts.reset
-      prefs = scope.preferences
-      # have to check for the case where you had already chosen live or work (individual)
-      # but now have changed your eligibility to where you will see the liveWork combo
-      if !prefs.liveWorkInSf_preference && (prefs.liveInSf || prefs.workInSf)
-        preference = 'liveInSf' if prefs.liveInSf
-        preference = 'workInSf' if prefs.workInSf
-        prefs.liveWorkInSf_preference = preference
-        prefs.liveWorkInSf = true
-      # liveWorkInSf_preference will be 'liveInSf', 'workInSf' or undefined
-      preference = prefs.liveWorkInSf_preference
+      scope.checkForLiveOrWorkValues()
+      # liveWorkInSf_preference will be 'liveInSf', 'workInSf' or null/undefined
+      preference = scope.preferences.liveWorkInSf_preference
       if preference
         scope.preference = preference
         scope.setup_preference_variables(preference)
         scope.preferences[preference] = true
+
+    scope.checkForLiveOrWorkValues = ->
+      prefs = scope.preferences
+      # have to check for the case where you had already chosen live or work (individual)
+      # but now have changed your eligibility to where you will see the liveWork combo
+      if scope.showPreference('liveWorkInSf')
+        if !prefs.liveWorkInSf_preference && (prefs.liveInSf || prefs.workInSf)
+          preference = 'liveInSf' if prefs.liveInSf
+          preference = 'workInSf' if prefs.workInSf
+          prefs.liveWorkInSf_preference = preference
+          prefs.liveWorkInSf = true
+      else
+        # if liveWork combo is no longer shown then reset its values
+        prefs.liveWorkInSf_preference = null
+        prefs.liveWorkInSf = null
 
     scope.refresh_member_dropdown = ->
       oneEligibleWithHouseholdMembers = (scope.eligible_members().length == 1) && (scope._householdSize() > 1)

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "angular-translate": "~2.11.0",
     "angular-translate-loader-static-files": "~2.11.0",
     "js-yaml": "~3.6.0",
-    "ng-file-upload": "~12.0.4",
+    "ng-file-upload": "12.2.13",
     "ng-idle": "~1.2.2",
     "angular-aria": "~1.5.6",
     "angular-scroll": "1.0.0",


### PR DESCRIPTION
… proof upload (filename or date not showing, not triggering validation properly)

- upgraded version of `ng-file-upload` to include some new bugfixes in the library
- added `type="button"` to upload button to prevent it from trying to submit prematurely
- re-initialized `Service.preferences` in the `uploadProof` function which also seemed to fix some strange issues
