### PR TITLE
Chores/e2e ci #134472139

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Run:
 
 To run E2E tests:
 - On a tab run `rails s`
-- On another tab, run `webdriver-manager start`
-- On a final tab, run `protractor spec/e2e/conf.js`
+- On another tab, run `npm run e2e` -- this will start the selenium webdriver in the background and run the protractor tests
+
+Note: These tests will run on Semaphore (our CI) as well for every review app and QA deploy.
 
 ### Acceptance/Feature Apps ###
 

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,6 @@
     "ng-idle": "1.2.2",
     "ng-text-truncate": "Exygy/ng-text-truncate",
     "ng-token-auth": "0.0.29",
-    "ngstorage": "0.3.11",
-    "protractor": "4.0.10"
+    "ngstorage": "0.3.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "grunt-contrib-copy": "0.8.1",
     "grunt-replace": "0.11.0",
     "grunt-sort-json": "0.0.5",
-    "protractor": "4.0.10"
+    "protractor": "4.0.10",
+    "npm-run-all": "4.0.0"
   },
   "dependencies": {
     "bower": "1.7.9",
@@ -22,7 +23,10 @@
     "npm": "2.1.x"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "webdriver-start": "./node_modules/protractor/bin/webdriver-manager start",
+    "protractor": "./node_modules/protractor/bin/protractor spec/e2e/conf.js",
+    "e2e": "npm-run-all -p -r webdriver-start protractor"
   },
   "license": "GNU GENERAL PUBLIC LICENSE",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.8.1",
     "grunt-replace": "0.11.0",
-    "grunt-sort-json": "0.0.5"
+    "grunt-sort-json": "0.0.5",
+    "protractor": "4.0.10"
   },
   "dependencies": {
     "bower": "1.7.9",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "bower": "1.7.9",
-    "coffee-script": "1.11.1"
+    "coffee-script": "1.11.1",
+    "dotenv": "^2.0.0"
   },
   "engines": {
     "node": "4.1.x",

--- a/spec/e2e/conf.js
+++ b/spec/e2e/conf.js
@@ -1,8 +1,16 @@
 require('coffee-script').register()
+require('dotenv').config()
+
+var baseUrl = 'https://dahlia-qa.herokuapp.com'
+
+if (process.env.PULL_REQUEST_NUMBER) {
+  baseUrl = 'https://dahlia-qa-' + process.env.PULL_REQUEST_NUMBER + '.herokuapp.com'
+}
 
 exports.config = {
-  framework: 'jasmine',
-  seleniumAddress: 'http://localhost:4444/wd/hub',
-  baseUrl: 'http://localhost:3000/',
-  specs: [ 'short-form.coffee' ]
+ sauceUser: process.env.SAUCE_USERNAME,
+ sauceKey: process.env.SAUCE_ACCESS_KEY,
+ framework: 'jasmine',
+ baseUrl: baseUrl,
+ specs: [ 'short-form.coffee' ],
 }

--- a/spec/e2e/conf.js
+++ b/spec/e2e/conf.js
@@ -1,16 +1,7 @@
 require('coffee-script').register()
-require('dotenv').config()
-
-var baseUrl = 'https://dahlia-qa.herokuapp.com'
-
-if (process.env.PULL_REQUEST_NUMBER) {
-  baseUrl = 'https://dahlia-qa-' + process.env.PULL_REQUEST_NUMBER + '.herokuapp.com'
-}
 
 exports.config = {
- sauceUser: process.env.SAUCE_USERNAME,
- sauceKey: process.env.SAUCE_ACCESS_KEY,
  framework: 'jasmine',
- baseUrl: baseUrl,
+ baseUrl: 'http://localhost:3000/',
  specs: [ 'short-form.coffee' ],
 }


### PR DESCRIPTION
Semaphore is running the e2e tests headless - meaning it starts its own rails and selenium server and runs protractor from the semaphore environment. This way we don't need to wait for the PR review app to run the tests, which prevents us from running into a lot of obstacles such as waiting for the review app to finish deploying before running the tests. It also means we don't need to pay for and rely on saucelabs to run it for us. 