### PR TITLE
[#141844541] Fixes "create account" after submission

### DIFF
--- a/app/assets/javascripts/account/AccountService.js.coffee
+++ b/app/assets/javascripts/account/AccountService.js.coffee
@@ -50,18 +50,19 @@ AccountService = (
 
 
   Service.createAccount = (shortFormSession) ->
+    # loading overlay will be cleared on success by a state transition in the controller
     bsLoadingOverlayService.start()
     Service.clearAccountMessages()
     if shortFormSession
       Service.userAuth.user.temp_session_id = shortFormSession.uid
     $auth.submitRegistration(Service._createAccountParams())
       .success((response) ->
-        bsLoadingOverlayService.stop()
         angular.copy(response.data, Service.createdAccount)
         angular.copy(Service.userAuthDefaults, Service.userAuth)
         Service.clearAccountMessages()
         return true
       ).error((response) ->
+        # for errors we manually stop the loading overlay
         bsLoadingOverlayService.stop()
         msg = response.errors.full_messages[0]
         if msg == 'Email already in use'
@@ -74,11 +75,11 @@ AccountService = (
       )
 
   Service.signIn = ->
+    # loading overlay will be cleared on success by a state transition in the controller
     bsLoadingOverlayService.start()
     Service.clearAccountMessages()
     $auth.submitLogin(Service.userAuth.user)
       .then((response) ->
-        bsLoadingOverlayService.stop()
         # reset userAuth object
         angular.copy(Service.userAuthDefaults, Service.userAuth)
         if response.signedIn
@@ -86,6 +87,7 @@ AccountService = (
           Service._reformatDOB()
           return true
       ).catch((response) ->
+        # for errors we manually stop the loading overlay
         bsLoadingOverlayService.stop()
         return false
       )

--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -112,6 +112,9 @@
         toState.name == 'dahlia.short-form-application.create-account' &&
         fromState.name != 'dahlia.short-form-application.sign-in')
           AccountService.rememberShortFormState(fromState.name)
+      if (fromState.name == 'dahlia.short-form-application.confirmation')
+        # clear out remembered state when coming from confirmation
+        AccountService.rememberShortFormState(null)
       if (toState.name == 'dahlia.short-form-application.review-sign-in')
         # always remember the review-sign-in page when we go to it (mainly for supporting "forgot pw")
         AccountService.rememberShortFormState(toState.name)

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee.erb
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee.erb
@@ -424,17 +424,21 @@ ShortFormApplicationService = (
       Service.application.status = 'submitted'
 
     Service.application.applicationSubmittedDate = moment().tz('America/Los_Angeles').format('YYYY-MM-DD')
+    # this gets stored in the metadata of the application to verify who's trying to "claim" it after submission
+    Service.application.session_uid = Service.session_uid
     params =
       application: ShortFormDataService.formatApplication(Service.listing.Id, Service.application)
       uploaded_file:
         session_uid: Service.session_uid
-    if options.attachToAccount
-      params.temp_session_id = Service.session_uid
 
     if params.application.id
       # update
       id = params.application.id
-      appSubmission = $http.put("/api/v1/short-form/application/#{id}", params)
+      if options.attachToAccount
+        params.temp_session_id = Service.session_uid
+        appSubmission = $http.put("/api/v1/short-form/claim-application/#{id}", params)
+      else
+        appSubmission = $http.put("/api/v1/short-form/application/#{id}", params)
     else
       # create
       appSubmission = $http.post('/api/v1/short-form/application', params)

--- a/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
@@ -186,11 +186,13 @@ ShortFormDataService = () ->
     return application
 
   Service._formatMetadata = (application) ->
-    formMetadata = {
+    formMetadata =
       completedSections: application.completedSections
-    }
+      session_uid: application.session_uid
+
     application.formMetadata = JSON.stringify(formMetadata)
     delete application.completedSections
+    delete application.session_uid
     return application
 
   #############################################

--- a/app/assets/javascripts/short-form/templates/g1-confirmation.html.slim
+++ b/app/assets/javascripts/short-form/templates/g1-confirmation.html.slim
@@ -31,7 +31,7 @@
 
   .button-pager ng-if="!loggedIn()"
     .button-pager_row.primary
-      a.button.primary.radius ui-sref="dahlia.short-form-application.create-account"
+      a.button.primary.radius#create-account ui-sref="dahlia.short-form-application.create-account"
         | {{'CREATE_ACCOUNT.CREATE_AN_ACCOUNT' | translate}}
     .button-pager_row
       button.button.button-link.button-lined.small-text-center.expand-small ui-sref="dahlia.welcome"

--- a/app/services/salesforce_service/short_form_service.rb
+++ b/app/services/salesforce_service/short_form_service.rb
@@ -46,6 +46,15 @@ module SalesforceService
       contact_id == application['primaryApplicant']['contactId']
     end
 
+    def self.can_claim?(session_uid, application)
+      return false unless application['status'].casecmp('submitted').zero?
+      metadata = JSON.parse(application['formMetadata'])
+      # only claimable if they are in the same user session
+      session_uid == metadata['session_uid']
+    rescue
+      false
+    end
+
     def self.submitted?(application)
       application['status'] == 'Submitted'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
         get 'application/:id' => 'short_form#show_application'
         post 'application' => 'short_form#submit_application'
         put 'application/:id' => 'short_form#update_application'
+        put 'claim-application/:id' => 'short_form#claim_submitted_application'
         delete 'application/:id' => 'short_form#delete_application'
         post 'proof' => 'short_form#upload_proof'
         delete 'proof' => 'short_form#delete_proof'

--- a/spec/e2e/features/short_form.feature
+++ b/spec/e2e/features/short_form.feature
@@ -3,7 +3,7 @@ Feature: Short Form Application
     I should be able to fill out the short form application
     In order to apply online to a listing
 
-    Scenario: Submitting a basic application
+    Scenario: Submitting a basic application, creating an account on the confirmation page
       Given I go to the first page of the Test Listing application
       When I fill out the Name page as "Jane Doe"
       And I fill out the Contact page with an address (non-NRHP match) and WorkInSF
@@ -20,6 +20,11 @@ Feature: Short Form Application
       And I continue confirmation without signing in
       And I agree to the terms and submit
       Then I should see my lottery number on the confirmation page
+      # now that we've submitted, also create an account
+      When I click the Create Account button
+      And I fill out my account info with my locked-in application email
+      And I submit the Create Account form
+      Then I should be on the login page with the email confirmation popup
 
     Scenario: Opting in to live/work then saying no to workInSf
       Given I go to the first page of the Test Listing application

--- a/spec/e2e/step_definitions/short_form_steps.coffee
+++ b/spec/e2e/step_definitions/short_form_steps.coffee
@@ -6,6 +6,7 @@ EC = protractor.ExpectedConditions
 # QA "280 Fell"
 listingId = 'a0W0P00000DZTkAUAX'
 sessionEmail = chance.email()
+janedoeEmail = chance.email()
 accountPassword = 'password123'
 
 # reusable functions
@@ -63,11 +64,11 @@ module.exports = ->
     element(By.id('submit')).click()
 
   @When 'I fill out the Contact page with an address (non-NRHP match) and WorkInSF', ->
-    fillOutContactPage({email: 'jane@doe.com'})
+    fillOutContactPage({email: janedoeEmail})
     element(By.id('submit')).click()
 
   @When 'I fill out the Contact page with an address (NRHP match) and WorkInSF', ->
-    fillOutContactPage({email: 'jane@doe.com', address1: '1222 Harrison St.'})
+    fillOutContactPage({email: janedoeEmail, address1: '1222 Harrison St.'})
     element(By.id('submit')).click()
 
   @When 'I fill out the Contact page with my account email, an address (non-NRHP match) and WorkInSF', ->
@@ -177,9 +178,17 @@ module.exports = ->
   @When 'I click the Save and Finish Later button', ->
     element(By.id('save_and_finish_later')).click()
 
+  @When 'I click the Create Account button', ->
+    element(By.id('create-account')).click()
+
   @When 'I fill out my account info', ->
     element(By.id('auth_email')).sendKeys(sessionEmail)
     element(By.id('auth_email_confirmation')).sendKeys(sessionEmail)
+    element(By.id('auth_password')).sendKeys(accountPassword)
+    element(By.id('auth_password_confirmation')).sendKeys(accountPassword)
+
+  @When 'I fill out my account info with my locked-in application email', ->
+    element(By.id('auth_email_confirmation')).sendKeys(janedoeEmail)
     element(By.id('auth_password')).sendKeys(accountPassword)
     element(By.id('auth_password_confirmation')).sendKeys(accountPassword)
 

--- a/spec/requests/api/v1/short_form_spec.rb
+++ b/spec/requests/api/v1/short_form_spec.rb
@@ -120,6 +120,8 @@ describe 'ShortForm API' do
         .to receive(:attach_files_and_send_confirmation).and_return(true)
       allow_any_instance_of(Api::V1::ShortFormController)
         .to receive(:delete_draft_application).and_return(true)
+      allow_any_instance_of(Api::V1::ShortFormController)
+        .to receive(:user_can_claim?).and_return(true)
     end
 
     it 'returns success response' do
@@ -147,6 +149,30 @@ describe 'ShortForm API' do
         put url, params, @auth_headers
       end
       expect(response).not_to be_success
+    end
+  end
+
+  describe 'claim_submitted_application' do
+    # NOTE: this doesn't really test that the user should be *allowed* to claim
+    # just that the API call functionally works
+    before do
+      allow_any_instance_of(Api::V1::ShortFormController)
+        .to receive(:user_can_claim?).and_return(true)
+      allow_any_instance_of(Api::V1::ShortFormController)
+        .to receive(:attach_files_and_send_confirmation).and_return(true)
+      allow_any_instance_of(Api::V1::ShortFormController)
+        .to receive(:delete_draft_application).and_return(true)
+    end
+    it 'returns success response' do
+      VCR.use_cassette('shortform/claim_submitted_application') do
+        url = '/api/v1/short-form/claim-application/a0o0P0000093KJ0.json'
+        file = './spec/javascripts/fixtures/json/valid-short-form-example.json'
+        params = JSON.parse(File.read(file))
+        params['temp_session_id'] = 'xyz123'
+        params = clean_json_for_vcr(params)
+        put url, params, @auth_headers
+      end
+      expect(response).to be_success
     end
   end
 

--- a/spec/vcr/shortform/claim_submitted_application.yml
+++ b/spec/vcr/shortform/claim_submitted_application.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://test.salesforce.com/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<<SALESFORCE_CLIENT_ID>>&client_secret=<<SALESFORCE_CLIENT_SECRET>>&username=<<SALESFORCE_USERNAME>>&password=<<SALESFORCE_PASSWORD>><<SALESFORCE_SECURITY_TOKEN>>
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 16 Mar 2017 19:34:26 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=1ph36cvJRF6l6yxohoPpRg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        15-May-2017 19:34:26 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      X-Readonlymode:
+      - 'false'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<<ACCESS_TOKEN>>","instance_url":"https://sfhousing--QA.cs51.my.salesforce.com","id":"https://test.salesforce.com/id/00D4B000000D2n3UAC/005U00000066jl9IAA","token_type":"Bearer","issued_at":"1489692866551","signature":"Ro+pa39/AZESGK0xzspnKGsKJWEKtU/XdjK3qfvHEZs="}'
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 19:34:28 GMT
+- request:
+    method: get
+    uri: https://sfhousing--qa.cs51.my.salesforce.com/services/apexrest/shortForm/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 16 Mar 2017 19:34:27 GMT
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="6m4uJ26w5zoo/DLDmYNWG1dWpZ8/GSCPe6SBri8Euw0=";
+        max-age=86400; report-uri="https://calm-dawn-26291.herokuapp.com/hpkp-report/00D4B000000D2n3";
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Set-Cookie:
+      - BrowserId=RSMbESufQMGpbESlo89JSQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        15-May-2017 19:34:27 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 19:34:28 GMT
+- request:
+    method: post
+    uri: https://sfhousing--qa.cs51.my.salesforce.com/services/apexrest/shortForm
+    body:
+      encoding: UTF-8
+      string: '{"id":null,"primaryApplicant":{"phone":"2222222222","firstName":"Christine","lastName":"Dolendo","phoneType":"Home","alternatePhone":null,"alternatePhoneType":null,"gender":"Male","dob":"1990-2-2","contactId":"0030P00001y3eLHQAY","webAppID":1},"householdMembers":[{"firstName":"Obie","lastName":"Kanobi","relationship":"Spouse","dob":"1990-7-23"}],"listingID":"a0WU000000ClNXGMA3","referral":"","annualIncome":"20000","applicationSubmissionType":"Electronic","applicationSubmittedDate":"2016-09-07","status":"submitted"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 16 Mar 2017 19:34:27 GMT
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="6m4uJ26w5zoo/DLDmYNWG1dWpZ8/GSCPe6SBri8Euw0=";
+        max-age=86400; report-uri="https://calm-dawn-26291.herokuapp.com/hpkp-report/00D4B000000D2n3";
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Set-Cookie:
+      - BrowserId=VdhDOYDoQ0mFzWzu7ClunQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        15-May-2017 19:34:27 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"worksInSfPreferenceID":null,"workInSfPreferenceProof":null,"workInSfPreferenceNatKey":null,"status":"Submitted","referral":null,"primaryApplicant":{"zip":null,"yCoordinate":null,"xCoordinate":null,"workInSf":null,"whichComponentOfLocatorWasUsed":null,"webAppID":"1","state":null,"sexualOrientationOther":null,"sexualOrientation":null,"relationship":null,"race":null,"phoneType":"Home","phone":"2222222222","noPhone":false,"noEmail":false,"noAddress":false,"neighborhoodPreferenceMatch":null,"middleName":null,"mailingZip":null,"mailingState":null,"mailingCity":null,"mailingAddress":null,"lastName":"Dolendo","languageOther":null,"language":null,"hiv":false,"hasSameAddressAsApplicant":null,"hasAltMailingAddress":false,"genderOther":null,"gender":"Male","firstName":"Christine","ethnicity":null,"email":null,"DOB":"1990-02-02","contactId":"0030P00001y3eLHQAY","city":null,"candidateScore":null,"appMemberType":"Primary
+        Applicant","appMemberId":"a0n4B000000FsaOQAS","alternatePhoneType":null,"alternatePhone":null,"alternateContactTypeOther":null,"alternateContactType":null,"agency":null,"address":null},"neighborhoodResidencePreferenceNatKey":null,"neighborhoodPreferenceProof":null,"neighborhoodPreferenceOptOut":false,"neighborhoodPreferenceID":null,"name":"APP-00041014","monthlyIncome":null,"lotteryNumberManual":null,"lotteryNumber":"00041014","liveWorkOptOut":false,"liveInSfPreferenceProof":null,"liveInSfPreferencePaper":false,"liveInSfPreferenceNatKey":null,"liveInSfPreferenceID":null,"listingID":"a0WU000000ClNXGMA3","id":"a0o4B000000WkB6QAK","householdVouchersSubsidies":null,"householdMembers":[{"zip":null,"yCoordinate":null,"xCoordinate":null,"workInSf":null,"whichComponentOfLocatorWasUsed":null,"webAppID":null,"state":null,"sexualOrientationOther":null,"sexualOrientation":null,"relationship":"Spouse","race":null,"phoneType":null,"phone":null,"noPhone":false,"noEmail":false,"noAddress":false,"neighborhoodPreferenceMatch":null,"middleName":null,"mailingZip":null,"mailingState":null,"mailingCity":null,"mailingAddress":null,"lastName":"Kanobi","languageOther":null,"language":null,"hiv":false,"hasSameAddressAsApplicant":null,"hasAltMailingAddress":false,"genderOther":null,"gender":null,"firstName":"Obie","ethnicity":null,"email":null,"DOB":"1990-07-23","contactId":null,"city":null,"candidateScore":null,"appMemberType":"Household
+        Member","appMemberId":"a0n4B000000FsaNQAS","alternatePhoneType":null,"alternatePhone":null,"alternateContactTypeOther":null,"alternateContactType":null,"agency":null,"address":null}],"formMetadata":null,"displacedPreferenceOptOut":false,"displacedPreferenceNatKey":null,"displacedPreferenceID":null,"certOfPreferenceOptOut":false,"certOfPreferenceNatKey":null,"certOfPreferenceID":null,"applicationSubmittedDate":"2016-09-07","applicationSubmissionType":"Electronic","applicationLanguage":"English","annualIncome":20000.00,"alternateContact":null,"agreeToTerms":false}'
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 19:34:31 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Resurrected some of the "claim_submitted_application" functions which were actually relevant to this feature, but made it much simpler and less convoluted than it was before. Uses formMetadata to verify that the application belongs to the same user session as the person trying to "claim" the application by creating an account after the app has already been submitted.

