### PR TITLE
Updates to phantomjs 2.1.1 from version 1.9.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :development, :test do
   gem 'jquery-rails' # only needed for jasmine-jquery
   gem 'jasmine', github: 'pivotal/jasmine-gem'
   gem 'jasmine-jquery-rails' # used for functions like `getJSONFixture`
-  gem 'phantomjs', '~> 1.9.8.0' # until we upgrade to 2.1 and also update semaphoreCI
+  gem 'phantomjs', '~> 2.1.1'
   gem 'pry'
   gem 'pry-rails'
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
-    phantomjs (1.9.8.0)
+    phantomjs (2.1.1.0)
     pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -374,7 +374,7 @@ DEPENDENCIES
   oj_mimic_json
   overcommit
   pg
-  phantomjs (~> 1.9.8.0)
+  phantomjs (~> 2.1.1)
   pry
   pry-rails
   puma

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,4 @@
-workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['MAX_THREADS'] || 5)
 threads threads_count, threads_count
 


### PR DESCRIPTION
Now that semaphore supports easily switching versions of phantomJS by adding one config command, this makes sense to do. Angular 1.5+ doesn't play well with phantomJS v1. 