### PR TITLE
ensure saving geocoder fields even after loading draft

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
@@ -261,7 +261,8 @@ ShortFormDataService = () ->
       'noPhone', 'noEmail', 'noAddress', 'hasAltMailingAddress',
       'email', 'firstName', 'middleName', 'lastName', 'neighborhoodPreferenceMatch',
       'phone', 'phoneType', 'alternatePhone', 'alternatePhoneType', 'ethnicity',
-      'gender', 'genderOther', 'race', 'sexualOrientation', 'sexualOrientationOther'
+      'gender', 'genderOther', 'race', 'sexualOrientation', 'sexualOrientationOther',
+      'xCoordinate', 'yCoordinate', 'whichComponentOfLocatorWasUsed', 'candidateScore',
     ]
     applicant = _.pick contact, whitelist
     applicant.mailing_address = Service._reformatMailingAddress(contact)


### PR DESCRIPTION
quick fix to make sure geocoder fields get preserved, not only when you input your address but after loading a draft where you had previously stored geocoder metadata. 