### PR TITLE
Chores/version and security updates

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,7 @@
 languages:
   Ruby: true
   JavaScript: true
+exclude_paths:
+  - "lib/assets"
+  # code climate complains a bunch about our toolkit.css -- how useful is this?
+  - "app/assets/stylesheets"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,5 +4,5 @@ languages:
   JavaScript: true
 exclude_paths:
   - "lib/assets"
-  # code climate complains a bunch about our toolkit.css -- how useful is this?
+  # code climate complains a bunch about our toolkit.css -- is it useful to validate our CSS?
   - "app/assets/stylesheets"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source 'https://rubygems.org'
 ruby '2.2.3'
 
-gem 'rails', '~> 4.2.7'
+# same method is used in https://github.com/rails/rails/blob/master/Gemfile
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
+gem 'rails', '~> 4.2.8'
 gem 'rails-api'
 
 # Use SCSS for stylesheets
@@ -57,6 +63,8 @@ gem 'hashie'
 gem 'active_model-errors_details'
 
 gem 'sitemap_generator', github: 'Exygy/sitemap_generator'
+
+gem 'nokogiri', '~> 1.6.8'
 
 # http requests made easy
 gem 'http', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'active_model-errors_details'
 
 gem 'sitemap_generator', github: 'Exygy/sitemap_generator'
 
-gem 'nokogiri', '~> 1.6.8'
+gem 'nokogiri', '~> 1.7.1'
 
 # http requests made easy
 gem 'http', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     multipart-post (2.0.0)
     netrc (0.11.0)
     newrelic_rpm (3.16.0.318)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     oj (2.16.1)
     oj_mimic_json (1.0.1)
@@ -367,7 +367,7 @@ DEPENDENCIES
   jquery-rails
   memcachier
   newrelic_rpm
-  nokogiri (~> 1.6.8)
+  nokogiri (~> 1.7.1)
   oj
   oj_mimic_json
   overcommit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 GIT
-  remote: git://github.com/Exygy/sitemap_generator.git
+  remote: https://github.com/Exygy/sitemap_generator.git
   revision: 804c7e44070c63c27ddd373a8116e50596a37524
   specs:
     sitemap_generator (5.2.0)
       builder (~> 3.0)
 
 GIT
-  remote: git://github.com/Exygy/street-address.git
+  remote: https://github.com/Exygy/street-address.git
   revision: b505ad8c9710cab53ca97c6267ed8971e61b025f
   specs:
     StreetAddress (2.0.0)
 
 GIT
-  remote: git://github.com/pivotal/jasmine-gem.git
-  revision: b58ea472656af3a1e8409c0675c0f1b877aef162
+  remote: https://github.com/pivotal/jasmine-gem.git
+  revision: cbdad51e5b203e82ed47f09909063994823cc20a
   specs:
-    jasmine (2.5.1)
-      jasmine-core (>= 2.5.1, < 3.0.0)
+    jasmine (2.6.0)
+      jasmine-core (>= 2.6.0, < 3.0.0)
       phantomjs
       rack (>= 1.2.1)
       rake
@@ -24,44 +24,43 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.2.7.1)
-      actionpack (= 4.2.7.1)
-      actionview (= 4.2.7.1)
-      activejob (= 4.2.7.1)
+    actionmailer (4.2.8)
+      actionpack (= 4.2.8)
+      actionview (= 4.2.8)
+      activejob (= 4.2.8)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
     actionmailer-text (0.1.1)
       actionmailer
       htmlentities
-    actionpack (4.2.7.1)
-      actionview (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    actionpack (4.2.8)
+      actionview (= 4.2.8)
+      activesupport (= 4.2.8)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    actionview (4.2.8)
+      activesupport (= 4.2.8)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_model-errors_details (1.3.0)
       activemodel (>= 3.2.13, < 5.0.0.beta1)
       activesupport
-    activejob (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activejob (4.2.8)
+      activesupport (= 4.2.8)
       globalid (>= 0.3.0)
-    activemodel (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activemodel (4.2.8)
+      activesupport (= 4.2.8)
       builder (~> 3.1)
-    activerecord (4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activerecord (4.2.8)
+      activemodel (= 4.2.8)
+      activesupport (= 4.2.8)
       arel (~> 6.0)
-    activesupport (4.2.7.1)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -70,7 +69,7 @@ GEM
       railties (>= 4.2, < 6)
       sprockets (>= 3.0, < 5)
       tilt
-    arel (6.0.3)
+    arel (6.0.4)
     ast (2.3.0)
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -81,7 +80,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bower-rails (0.10.0)
-    builder (3.2.2)
+    builder (3.2.3)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     code_analyzer (0.4.5)
@@ -96,7 +95,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dalli (2.7.6)
@@ -135,8 +134,8 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.0)
+      activesupport (>= 4.2.0)
     hashdiff (0.3.0)
     hashie (3.4.4)
     htmlentities (4.3.4)
@@ -149,9 +148,9 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
-    i18n (0.7.0)
+    i18n (0.8.1)
     iniparse (1.4.2)
-    jasmine-core (2.5.2)
+    jasmine-core (2.6.1)
     jasmine-jquery-rails (2.0.3)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -160,23 +159,22 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
+    mail (2.6.5)
       mime-types (>= 1.16, < 4)
     memcachier (0.0.2)
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
     newrelic_rpm (3.16.0.318)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     oj (2.16.1)
     oj_mimic_json (1.0.1)
     orm_adapter (0.5.0)
@@ -187,7 +185,6 @@ GEM
       ast (~> 2.2)
     pg (0.18.4)
     phantomjs (2.1.1.0)
-    pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -198,29 +195,29 @@ GEM
     puma (3.6.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.7.1)
-      actionmailer (= 4.2.7.1)
-      actionpack (= 4.2.7.1)
-      actionview (= 4.2.7.1)
-      activejob (= 4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activerecord (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    rails (4.2.8)
+      actionmailer (= 4.2.8)
+      actionpack (= 4.2.8)
+      actionview (= 4.2.8)
+      activejob (= 4.2.8)
+      activemodel (= 4.2.8)
+      activerecord (= 4.2.8)
+      activesupport (= 4.2.8)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.7.1)
+      railties (= 4.2.8)
       sprockets-rails
-    rails-api (0.4.0)
+    rails-api (0.4.1)
       actionpack (>= 3.2.11)
       railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -237,9 +234,9 @@ GEM
       ruby-progressbar
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.5)
-    railties (4.2.7.1)
-      actionpack (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    railties (4.2.8)
+      actionpack (= 4.2.8)
+      activesupport (= 4.2.8)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
@@ -310,7 +307,7 @@ GEM
       slim (~> 3.0)
     slop (3.6.0)
     spring (1.7.1)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -318,13 +315,13 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     temple (0.7.7)
-    thor (0.19.1)
+    thor (0.19.4)
     thor-rails (0.0.1)
       rails
       thor
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
@@ -370,6 +367,7 @@ DEPENDENCIES
   jquery-rails
   memcachier
   newrelic_rpm
+  nokogiri (~> 1.6.8)
   oj
   oj_mimic_json
   overcommit
@@ -380,7 +378,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rack-rewrite (~> 1.5.0)
-  rails (~> 4.2.7)
+  rails (~> 4.2.8)
   rails-api
   rails_12factor
   rails_best_practices

--- a/app/assets/javascripts/listings/ListingController.js.coffee
+++ b/app/assets/javascripts/listings/ListingController.js.coffee
@@ -7,6 +7,7 @@ ListingController = (
   $state,
   $sce,
   $sanitize,
+  $timeout,
   $filter,
   Carousel,
   SharedService,
@@ -118,7 +119,9 @@ ListingController = (
   $scope.carouselHeight = 300
   $scope.Carousel = Carousel
   $scope.adjustCarouselHeight = (elem) ->
-    $scope.$apply ->
+    # for why we need $timeout, see:
+    # http://stackoverflow.com/a/18996042/260495
+    $timeout ->
       $scope.carouselHeight = elem[0].offsetHeight
 
   $scope.listingImages = (listing) ->
@@ -304,6 +307,7 @@ ListingController.$inject = [
   '$state',
   '$sce',
   '$sanitize',
+  '$timeout',
   '$filter',
   'Carousel',
   'SharedService',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 # Root controller from which all our controllers inherit.
 class ApplicationController < ActionController::Base
+  # not really used since we don't have any Rails-generated forms
+  # but still added for security + codeclimate happiness
+  protect_from_forgery
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,5 @@
 class ApplicationController < ActionController::Base
   # not really used since we don't have any Rails-generated forms
   # but still added for security + codeclimate happiness
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end

--- a/bower.json
+++ b/bower.json
@@ -1,21 +1,21 @@
 {
   "name": "sf-dahlia-web",
   "resolutions": {
-    "angular": "1.4.14",
+    "angular": "1.5.11",
     "angular-translate": "2.13.0"
   },
   "dependencies": {
-    "angular": "1.4.14",
-    "angular-aria": "1.4.14",
+    "angular": "1.5.11",
+    "angular-aria": "1.5.11",
     "angular-clipboard": "1.1.2",
     "angular-cookie": "4.1.0",
     "angular-filter": "0.5.11",
     "angular-foundation": "Exygy/angular-foundation-bower#dac08966b3bd28548296efc98d21e19a0af46c4c",
     "angular-linkify": "1.2.0",
     "angular-loading-overlay": "1.1.1",
-    "angular-mocks": "1.4.14",
+    "angular-mocks": "1.5.11",
     "angular-pageslide-directive": "1.0.13",
-    "angular-sanitize": "1.4.14",
+    "angular-sanitize": "1.5.11",
     "angular-scroll": "1.0.0",
     "angular-translate": "2.13.0",
     "angular-translate-loader-static-files": "2.13.0",


### PR DESCRIPTION
Also removes `toolkit.css` from codeclimate since it was popping up a lot of style syntax issues that aren't very helpful, and making it hard to sort through other more useful error checks. 