### PR TITLE
Fixes bug with httpInterceptor error handling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,6 @@
 //= require angular-pageslide-directive
 //= require ngstorage
 //= require angular-sanitize
-//= require angular-pageslide-directive
 //= require angular-clipboard
 //= require angular-filter
 //= require angular-translate

--- a/app/assets/javascripts/config/angularProviders.js.coffee
+++ b/app/assets/javascripts/config/angularProviders.js.coffee
@@ -14,7 +14,7 @@
     success = (response) ->
       response
     error = (response) ->
-      if response.status is 401 or 400
+      if _([400, 401]).includes(response.status)
         $rootScope.$broadcast "event:unauthorized"
         $location.path ""
         return response


### PR DESCRIPTION
Pierre noticed this when working on HBBF, the `or` case simply says `or 400` rather than saying the status should equal 401 or it should equal 400
