### PR TITLE
Features/Add accessibility labels to unit accessibility column #142811409

### DIFF
--- a/app/assets/javascripts/listings/templates/listing/_features.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_features.html.slim
@@ -55,7 +55,7 @@ accordion-heading
               td
                 | {{unit.Unit_Floor}}
               td
-                | {{unit.Other_Accessibility_Information}}
+                | {{unit.Priority_Type}}
 
   .content-tile.feature-tile
     .content-card.bg-dust


### PR DESCRIPTION
Implemented feature. The salesforce value that gets returned is a string for each unit, not an array, so I can only display the string and not concat with commas. I also need to be able to test for multiple accessibility labels for a unit. Can't seem to find a way to do that on salesforce. Will chat with Kristen tomorrow about that.