### PR TITLE
[#149973165] - Update lottery pdf url logic

### DIFF
--- a/app/assets/javascripts/listings/templates/listing/_lottery_modal_footer.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_lottery_modal_footer.html.slim
@@ -3,8 +3,13 @@ p.text-center.t-small.padding--3halves.no-margin.bg-dust
     | {{'LOTTERY.READ_ABOUT_PREFERENCES' | translate}}
 
 footer.modal-footer.text-center.padding--3halves ng-if="!lotteryRankingSubmitted"
-  p.t-small translate="LOTTERY.RESULTS_FROM" translate-value-date="{{listing.Lottery_Results_Date | date : 'MMM d, yyyy' }}"
-  p.t-small ng-if="lotteryBuckets.lotteryResultsURL"
-    a.a-dark ng-href="{{lotteryBuckets.lotteryResultsURL}}" target="_blank" data-event="gtm-download-lottery-results"
-      | {{'LOTTERY.LOTTERY_RESULTS_PDF_LINK' | translate}}
-  p.t-small.c-steel translate="LOTTERY.UNSORTED_RESULTS_NOTE"  translate-value-date="{{lotteryBuckets.lotteryDate | date : 'MMM d, yyyy' }}"
+
+  span ng-if="!lotteryBucketInfo.lotteryResultsURL"
+    p.t-small translate="LOTTERY.RESULTS_WILL_BE_POSTED_ON" translate-value-date="{{listing.Lottery_Results_Date | date : 'MMM d, yyyy' }}"
+
+  span ng-if="lotteryBucketInfo.lotteryResultsURL"
+    p.t-small translate="LOTTERY.RESULTS_FROM" translate-value-date="{{listing.Lottery_Results_Date | date : 'MMM d, yyyy' }}"
+    p.t-small ng-if="lotteryBucketInfo.lotteryResultsURL"
+      a.a-dark ng-href="{{lotteryBucketInfo.lotteryResultsURL}}" target="_blank" data-event="gtm-download-lottery-results"
+        | {{'LOTTERY.LOTTERY_RESULTS_PDF_LINK' | translate}}
+  p.t-small.c-steel translate="LOTTERY.UNSORTED_RESULTS_NOTE"  translate-value-date="{{lotteryBucketInfo.lotteryDate | date : 'MMM d, yyyy' }}"

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -667,6 +667,7 @@
         "RANKING_TITLE": "Your preference ranking",
         "READ_ABOUT_PREFERENCES": "Read About Housing Preferences",
         "RESULTS_FROM": "Results from {{date}}",
+        "RESULTS_WILL_BE_POSTED_ON": "Complete lottery results will be posted in pdf format on {{date}}",
         "UNSORTED_RESULTS_NOTE": "This PDF contains the unsorted lottery results from the housing lottery held on {{date}}.",
         "UP_TO_X_UNITS_AVAILABLE": "Up to {{units}} units",
         "VIEW_PREFERENCE_LIST": "View Preference List"


### PR DESCRIPTION
Nothing was working during the implementation, but then upon investigation, I noticed that the lottery modal footer was still referencing `lotteryBuckets` when the Service was using `lotteryBucketInfo` 😮  Anyway, fixed that naming and then the implementation worked as expected. Also, searched the codebase for any other `lotteryBuckets` reference in case any was left out. This should be the last of it.