### PR TITLE
Bugs/View submitted application warning #150871123

### DIFF
--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -59,7 +59,7 @@
         # Boolean for Logged in Users on the confirmation page of short form to remove the leave confirmation.
         loggedInConfirmation = (AccountService.loggedIn() && fromState.name == 'dahlia.short-form-application.confirmation')
         # Anonymous user coming from shortform and are on the confirmation page: change the leave message
-        if (fromState.name == 'dahlia.short-form-application.confirmation')
+        if (ShortFormApplicationService.isLeavingConfirmation(toState, fromState))
           leaveMessage = $translate.instant('T.ARE_YOU_SURE_YOU_WANT_TO_LEAVE_CONFIRMATION')
         else if (ShortFormApplicationService.isLeavingConfirmationToSignIn(toState, fromState))
           leaveMessage = $translate.instant('T.ARE_YOU_SURE_YOU_WANT_TO_LEAVE_SIGN_IN')

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -328,8 +328,8 @@ ShortFormApplicationController = (
     else
       $scope.checkIfNoPreferencesSelected()
 
-  $scope.customPreferencesClaimed = ->
-    ShortFormApplicationService.customPreferencesClaimed()
+  $scope.claimedCustomPreference = (preference) ->
+    ShortFormApplicationService.claimedCustomPreference(preference)
 
   # this is called after custom-preferences or preferences-programs
   $scope.checkIfNoPreferencesSelected = ->

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -479,10 +479,8 @@ ShortFormApplicationService = (
     prefList = prefList.concat(customPrefs)
     return !_.some(_.pick(Service.preferences, prefList))
 
-  Service.customPreferencesClaimed = ->
-    customPrefClaims = _.map Service.listing.customPreferences, (customPref) ->
-      Service.applicationHasPreference(customPref.listingPreferenceID)
-    return _.includes(customPrefClaims, true)
+  Service.claimedCustomPreference = (preference) ->
+    Service.applicationHasPreference(preference.listingPreferenceID)
 
   Service.applicationHasPreference = (preference) ->
     !! Service.preferences[preference]
@@ -569,6 +567,15 @@ ShortFormApplicationService = (
     fromState.name == 'dahlia.short-form-application.create-account' &&
       toState.name == 'dahlia.sign-in' &&
       Service.application.status.match(/submitted/i)
+
+  Service.isLeavingConfirmation = (toState, fromState) ->
+    Service.application.status.match(/submitted/i) &&
+      toState.name != 'dahlia.sign-in' &&
+      !Service.isShortFormPage(toState) &&
+      (fromState.name == 'dahlia.short-form-application.confirmation' ||
+      fromState.name == 'dahlia.short-form-application.review-submitted' ||
+      fromState.name == 'dahlia.short-form-application.create-account')
+
 
   Service.hittingBackFromConfirmation = (fromState, toState) ->
     # going from confirmation to a short form page that ISN'T "create-account" or "review"

--- a/app/assets/javascripts/short-form/templates/partials/_review-application-details.html.slim
+++ b/app/assets/javascripts/short-form/templates/partials/_review-application-details.html.slim
@@ -88,7 +88,7 @@ div ng-if="prioritiesSelectedExists()"
 
 / Preferences
 div ng-if="!atAutofillPreview()"
-  review-summary-section header="{{'LABEL.PREFERENCES' | translate}}" to="dahlia.short-form-application.preferences-programs"
+  review-summary-section header="{{'LABEL.PREFERENCES' | translate}}" to="dahlia.short-form-application.{{getLandingPage({name: 'Preferences'})}}"
 
   .app-inner
     p.info-item_name.sentence ng-if="applicantHasNoPreferences()"
@@ -118,7 +118,7 @@ div ng-if="!atAutofillPreview()"
     review-summary-item label="{{'LABEL.YOU_HAVE_CLAIMED' | translate}}" identifier="rentBurden" ng-if="preferences.rentBurden" get-labels="fileAttachmentsForRentBurden()"
       | {{'E3B_RENT_BURDEN_PREFERENCE.RENT_BURDEN_PREFERENCE' | translate}}
 
-    review-summary-item label="{{'LABEL.YOU_HAVE_CLAIMED' | translate}}" sub-label="{{'LABEL.FOR_USER' | translate: householdMemberForPreference(preference.listingPreferenceID) }}" ng-repeat="preference in listing.customPreferences" ng-if="customPreferencesClaimed()"
+    review-summary-item label="{{'LABEL.YOU_HAVE_CLAIMED' | translate}}" sub-label="{{'LABEL.FOR_USER' | translate: householdMemberForPreference(preference.listingPreferenceID) }}" ng-repeat="preference in listing.customPreferences" ng-if="claimedCustomPreference(preference)"
       | {{ preference.preferenceName }}
 
 / Income

--- a/spec/javascripts/controllers/short_form_application_controller_spec.coffee
+++ b/spec/javascripts/controllers/short_form_application_controller_spec.coffee
@@ -90,7 +90,7 @@ do ->
       hasCompleteRentBurdenFiles: ->
       hasCompleteRentBurdenFilesForAddress: jasmine.createSpy()
       cancelPreference: jasmine.createSpy()
-      customPreferencesClaimed: jasmine.createSpy()
+      claimedCustomPreference: jasmine.createSpy()
       resetUserData: ->
     fakeFunctions =
       fakeGetLandingPage: (section, application) ->
@@ -644,7 +644,7 @@ do ->
           scope.checkForCustomPreferences()
           expect(state.go).toHaveBeenCalledWith('dahlia.short-form-application.custom-preferences')
 
-    describe 'customPreferencesClaimed', ->
-      it ' calls customPreferencesClaimed on ShortFormApplicationService', ->
-        scope.customPreferencesClaimed()
-        expect(fakeShortFormApplicationService.customPreferencesClaimed).toHaveBeenCalled()
+    describe 'claimedCustomPreference', ->
+      it ' calls claimedCustomPreference on ShortFormApplicationService', ->
+        scope.claimedCustomPreference()
+        expect(fakeShortFormApplicationService.claimedCustomPreference).toHaveBeenCalled()

--- a/spec/javascripts/services/short_form_application_service_spec.coffee
+++ b/spec/javascripts/services/short_form_application_service_spec.coffee
@@ -938,7 +938,7 @@ do ->
             lease: {file: 'some file'}
         expect(ShortFormApplicationService.hasCompleteRentBurdenFiles()).toEqual false
 
-    describe 'customPreferencesClaimed', ->
+    describe 'claimedCustomPreference', ->
       beforeEach ->
         fakeListing = getJSONFixture('listings-api-show.json').listing
         ShortFormApplicationService.listing = fakeListing
@@ -948,10 +948,8 @@ do ->
 
       it 'returns true if custom preferences were claimed', ->
         ShortFormApplicationService.preferences = {'123456': true}
-        expect(ShortFormApplicationService.customPreferencesClaimed()).toEqual true
+        expect(ShortFormApplicationService.claimedCustomPreference(fakeCustomPreference)).toEqual true
 
       it 'returns false if custom preferences were not claimed', ->
         ShortFormApplicationService.preferences = {'liveInSf': true}
-        expect(ShortFormApplicationService.customPreferencesClaimed()).toEqual false
-
-
+        expect(ShortFormApplicationService.claimedCustomPreference(fakeCustomPreference)).toEqual false


### PR DESCRIPTION
Also includes some fixes I noticed on the review screen:

- Preferences "Edit" link was sending you to `preferences-programs` -- just a very outdated reference (perhaps from when that was the first page in the section?), now sends to `preferences-intro`
- _All_ custom preferences on the review screen were showing as long as you had selected _one_ of them -- fixed to only display the one you selected

