### PR TITLE
Bugs/skip to main content safari #150678472

### DIFF
--- a/app/assets/javascripts/shared/SharedService.js.coffee
+++ b/app/assets/javascripts/shared/SharedService.js.coffee
@@ -37,8 +37,6 @@ SharedService = ($http, $state, $window, $document) ->
       # when focus leaves this element, remove the tabindex
       angular.element(@).removeAttr('tabindex')
     el[0].focus()
-    # remove outline
-    el[0].blur()
 
   Service.focusOnBody = ->
     body = angular.element(document.body)


### PR DESCRIPTION
Turns out it was just the `blur()` we were doing that was making it not work in Safari (note Firefox is still another separate issue). I'm not noticing anything visual/bad about the outline we were trying to remove by blur, you can see the focus is on the body by clicking "skip to main content" and then scrolling all the way down the page to barely see that the blue outline is at the bottom, but this seems like a small price to pay to have the feature work cross-browser. 
