### PR TITLE
Bugs/catch wrong format root request #151452799

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'home#index'
+  root to: 'home#index', constraints: ->(req) { req.format == :html || req.format == '*/*' }
 
   mount_devise_token_auth_for(
     'User',


### PR DESCRIPTION
Applies the same format constraints that we already have on "*path" to the root route. This will make non-HTML requests to the home page trigger a 404 error instead of a 500 error. There wasn't any clear preferred alternative 4xx error for wrong formats in requests, so I decided to keep the existing 404 for wrong formats behavior that we already had and bring the root route into line with that.