### PR TITLE
Minor refactor for ShortFormApplicationService.loadApplication

### DIFF
--- a/app/assets/javascripts/account/AccountService.js.coffee
+++ b/app/assets/javascripts/account/AccountService.js.coffee
@@ -138,7 +138,7 @@ AccountService = (
   Service.signOut = ->
     # reset the user data immediately, then call signOut
     Service.setLoggedInUser({})
-    ShortFormApplicationService.resetUserData()
+    ShortFormApplicationService.resetApplicationData()
     $auth.signOut()
 
   # this gets run on init of the app in AngularConfig to check if we're logged in

--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -72,7 +72,7 @@
           # disable the onbeforeunload so that you are no longer bothered if you
           # try to reload the listings page, for example
           $window.removeEventListener 'beforeunload', ShortFormApplicationService.onExit
-          ShortFormApplicationService.resetUserData() unless toState.name == 'dahlia.short-form-review'
+          ShortFormApplicationService.resetApplicationData() unless toState.name == 'dahlia.short-form-review'
           if toParams.timeout
             AnalyticsService.trackTimeout('Application')
           else

--- a/app/assets/javascripts/config/angularRoutes.js.coffee
+++ b/app/assets/javascripts/config/angularRoutes.js.coffee
@@ -110,7 +110,7 @@
               setTimeout(ListingService.getListingAMI)
               setTimeout(ListingService.getListingUnits)
               setTimeout(ListingService.getListingPreferences)
-              setTimeout(ListingService.getLotteryBuckets)
+              setTimeout(ListingService.getLotteryBuckets) unless ListingService.lotteryIsUpcoming(ListingService.listing)
               setTimeout(ListingService.getListingDownloadURLs)
             ).catch( (response) ->
               deferred.reject(response)
@@ -1026,7 +1026,7 @@
       onExit: [
         'ShortFormApplicationService',
         (ShortFormApplicationService) ->
-          ShortFormApplicationService.resetUserData()
+          ShortFormApplicationService.resetApplicationData()
         ]
     })
     .state('dahlia.short-form-application.choose-draft', {

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -77,7 +77,7 @@ ShortFormApplicationController = (
     data =
       # will be null if the listing didn't have a screening Q
       answeredCommunityScreening: $scope.application.answeredCommunityScreening
-    ShortFormApplicationService.resetUserData(data)
+    ShortFormApplicationService.resetApplicationData(data)
     $scope.applicant = ShortFormApplicationService.applicant
     $scope.preferences = ShortFormApplicationService.preferences
     $scope.alternateContact = ShortFormApplicationService.alternateContact

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -78,7 +78,7 @@ ShortFormApplicationService = (
     ShortFormDataService.defaultCompletedSections = Service.applicationDefaults.completedSections
   ## -------
 
-  Service.resetUserData = (data = {}) ->
+  Service.resetApplicationData = (data = {}) ->
     application = _.merge({}, Service.applicationDefaults, data)
     angular.copy(application, Service.application)
     Service.applicant = Service.application.applicant
@@ -88,7 +88,7 @@ ShortFormApplicationService = (
     Service.householdMembers = Service.application.householdMembers
     Service.initServices()
 
-  Service.resetUserData()
+  Service.resetApplicationData()
   # --- end initialization
 
   Service.inputInvalid = (fieldName, form = Service.form.applicationForm, identifier) ->
@@ -774,10 +774,11 @@ ShortFormApplicationService = (
 
     # pull answeredCommunityScreening from the current session since that Q is answered first
     formattedApp.answeredCommunityScreening ?= Service.application.answeredCommunityScreening
-
-    Service.resetUserData(formattedApp)
+    # this will setup Service.application with the loaded data
+    Service.resetApplicationData(formattedApp)
     # one last step, reconcile any uploaded files with your saved member + preference data
-    Service.refreshPreferences('all') unless formattedApp.status.match(/submitted/i)
+    if !_.isEmpty(Service.application) && Service.application.status.match(/draft/i)
+      Service.refreshPreferences('all')
 
   Service.checkForProofPrefs = (formattedApp) ->
     proofPrefs = [

--- a/spec/javascripts/controllers/short_form_application_controller_spec.coffee
+++ b/spec/javascripts/controllers/short_form_application_controller_spec.coffee
@@ -91,7 +91,7 @@ do ->
       hasCompleteRentBurdenFilesForAddress: jasmine.createSpy()
       cancelPreference: jasmine.createSpy()
       claimedCustomPreference: jasmine.createSpy()
-      resetUserData: ->
+      resetApplicationData: ->
     fakeFunctions =
       fakeGetLandingPage: (section, application) ->
         'household-intro'
@@ -145,7 +145,7 @@ do ->
       spyOn(fakeShortFormApplicationService, 'validateApplicantAddress').and.callThrough()
       spyOn(fakeShortFormApplicationService, 'validateHouseholdMemberAddress').and.callThrough()
       spyOn(fakeShortFormApplicationService, 'hasHouseholdPublicHousingQuestion').and.callThrough()
-      spyOn(fakeShortFormApplicationService, 'resetUserData').and.callThrough()
+      spyOn(fakeShortFormApplicationService, 'resetApplicationData').and.callThrough()
       spyOn(fakeShortFormApplicationService, 'submitApplication').and.callFake ->
         state.go('dahlia.my-applications', {skipConfirm: true})
         deferred.promise
@@ -629,8 +629,8 @@ do ->
       beforeEach ->
         scope.resetAndStartNewApp()
 
-      it 'calls resetUserData on ShortFormApplicationService', ->
-        expect(fakeShortFormApplicationService.resetUserData).toHaveBeenCalled()
+      it 'calls resetApplicationData on ShortFormApplicationService', ->
+        expect(fakeShortFormApplicationService.resetApplicationData).toHaveBeenCalled()
 
       it 'unsets application autofill value', ->
         expect(scope.application.autofill).toBeUndefined()

--- a/spec/javascripts/services/account_service_spec.coffee
+++ b/spec/javascripts/services/account_service_spec.coffee
@@ -37,7 +37,7 @@ do ->
     fakeShortFormApplicationService =
       applicant: {}
       importUserData: ->
-      resetUserData: jasmine.createSpy()
+      resetApplicationData: jasmine.createSpy()
     modalMock =
       open: () ->
     fakeApplicant =
@@ -143,7 +143,7 @@ do ->
 
       it 'resets user data', ->
         AccountService.signOut()
-        expect(fakeShortFormApplicationService.resetUserData).toHaveBeenCalled()
+        expect(fakeShortFormApplicationService.resetApplicationData).toHaveBeenCalled()
         expect(AccountService.loggedInUser).toEqual {}
 
     describe 'validateUser', ->

--- a/spec/javascripts/services/short_form_application_service_spec.coffee
+++ b/spec/javascripts/services/short_form_application_service_spec.coffee
@@ -797,11 +797,11 @@ do ->
           .toHaveBeenCalledWith(data.application.listing)
 
       it 'resets user data', ->
-        spyOn(ShortFormApplicationService, 'resetUserData').and.callThrough()
+        spyOn(ShortFormApplicationService, 'resetApplicationData').and.callThrough()
         data =
           application: fakeShortForm
         ShortFormApplicationService.loadApplication(data)
-        expect(ShortFormApplicationService.resetUserData).toHaveBeenCalled()
+        expect(ShortFormApplicationService.resetApplicationData).toHaveBeenCalled()
 
     describe 'loadAccountApplication', ->
       beforeEach ->


### PR DESCRIPTION
- renames `resetUserData` to `resetApplicationData` for clarity
- doesn't call `ListingService.getLotteryBuckets` if it's still an open listing