### PR TITLE
Chores/remove sign in before submit #154821728

### DIFF
--- a/app/assets/javascripts/account/AccountService.js.coffee
+++ b/app/assets/javascripts/account/AccountService.js.coffee
@@ -22,7 +22,6 @@ AccountService = (
   Service.myApplications = []
   Service.currentApplication = {}
   Service.createdAccount = {}
-  Service.accountExists = false
   Service.rememberedShortFormState = null
   Service.accountError =
     messages: {}
@@ -135,16 +134,6 @@ AccountService = (
       else
         msg = $translate.instant("ERROR.PASSWORD_UPDATE")
       Service.accountError.messages.password = msg
-
-  Service.checkForAccount = (email) ->
-    $http.get("/api/v1/account/check-account?email=#{encodeURIComponent(email)}").success((data) ->
-      Service.accountExists = data.account_exists
-    ).catch( (data, status, headers, config) ->
-      Service.accountExists = false
-    )
-
-  Service.shortFormAccountExists = ->
-    Service.accountExists
 
   Service.signOut = ->
     # reset the user data immediately, then call signOut

--- a/app/assets/javascripts/config/angularRoutes.js.coffee
+++ b/app/assets/javascripts/config/angularRoutes.js.coffee
@@ -980,12 +980,6 @@
         AccountService.copyApplicantFields()
         AccountService.lockCompletedFields()
       ]
-      resolve:
-        application: [
-          '$state', 'ShortFormApplicationService', 'AccountService'
-          ($state, ShortFormApplicationService, AccountService) ->
-            AccountService.checkForAccount(ShortFormApplicationService.applicant.email)
-        ]
     })
     .state('dahlia.short-form-application.review-terms', {
       url: '/review-terms?loginMessage'

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -639,7 +639,6 @@ ShortFormApplicationController = (
         $scope.goToAndTrackFormSuccess('dahlia.my-applications', {skipConfirm: true})
       )
     else
-      # by going to My Applications without saving, we are choosing their old draft
       $scope.goToAndTrackFormSuccess('dahlia.my-applications', {skipConfirm: true})
 
   $scope.chooseAccountSettings = ->
@@ -653,10 +652,6 @@ ShortFormApplicationController = (
   ## account service
   $scope.loggedIn = ->
     AccountService.loggedIn()
-
-  $scope.shortFormAccountExists = ->
-    AccountService.shortFormAccountExists()
-
 
   ## translation helpers
   $scope.preferenceProofOptions = (pref_type) ->

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -750,14 +750,9 @@ ShortFormApplicationService = (
   Service.signInSubmitApplication = (opts = {}) ->
     # check if this user has already applied to this listing
     Service.getMyApplicationForListing(Service.listing.Id, {forComparison: true}).success((data) ->
-      previousApplication = data.application
-      if !_.isEmpty(previousApplication) && Service._previousIsSubmittedOrBothDrafts(previousApplication)
+      if !_.isEmpty(data.application) && Service._previousIsSubmittedOrBothDrafts(data.application)
         # if user already had an application for this listing
-        if opts.type == 'review-sign-in' && previousApplication.status.match(/draft/i)
-          # because we are finished/confirmed with the current draft, override the old one
-          Service.overridePreviousDraftId()
-        else if Service._previousIsSubmittedOrBothDrafts(previousApplication)
-          return Service._signInAndSkipSubmit(previousApplication)
+        return Service._signInAndSkipSubmit(data.application)
       changed = null
       if Service.application.status.match(/draft/i)
         if opts.type == 'review-sign-in' && Service.hasDifferentInfo(Service.applicant, opts.loggedInUser)
@@ -791,14 +786,10 @@ ShortFormApplicationService = (
       Service.application.status.match(/draft/i)
     )
 
-  Service.overridePreviousDraftId = ->
-    # override draft ID and proceed...  ->
-    Service.application.id = Service.accountApplication.id
 
   Service.keepCurrentDraftApplication = (loggedInUser) ->
     Service.importUserData(loggedInUser)
-    Service.overridePreviousDraftId()
-    # override draft ID and proceed...
+    Service.application.id = Service.accountApplication.id
     # now that we've overridden current application ID with our old one
     # submitApplication() will update our existing draft on salesforce
     Service.submitApplication()

--- a/app/assets/javascripts/short-form/templates/f1a-review-sign-in.html.slim
+++ b/app/assets/javascripts/short-form/templates/f1a-review-sign-in.html.slim
@@ -1,13 +1,9 @@
 .app-card.form-card
   short-form-header
-    div ng-if="!shortFormAccountExists()"
-      h2.app-card_question translate="F1A_REVIEW_SIGN_IN.TITLE"
+    h2.app-card_question
+      | {{'F1A_REVIEW_SIGN_IN.TITLE' | translate}}
 
-    div ng-if="shortFormAccountExists()"
-      h2.app-card_question translate="F1A_REVIEW_SIGN_IN.ACCOUNT_EXISTS.TITLE"
-      p.form-note translate="F1A_REVIEW_SIGN_IN.ACCOUNT_EXISTS.P1"
-
-  .button-pager ng-if="!shortFormAccountExists()"
+  .button-pager
     .button-pager_row.primary
       a#confirm_no_account.button.primary.radius ui-sref="dahlia.short-form-application.review-terms"
         | {{'F1A_REVIEW_SIGN_IN.CONTINUE_WITHOUT_AN_ACCOUNT' | translate}}
@@ -16,9 +12,9 @@
 
   .app-inner.inset
 
-    div ng-if="!shortFormAccountExists()"
-      h2.app-card_question translate="CREATE_ACCOUNT.ALREADY_HAVE_ACCOUNT"
-      p.form-note.margin-bottom translate="F1A_REVIEW_SIGN_IN.INSTRUCTIONS"
+    h2.app-card_question
+      | {{'CREATE_ACCOUNT.ALREADY_HAVE_ACCOUNT' | translate}}
+    p.form-note.margin-bottom translate="F1A_REVIEW_SIGN_IN.INSTRUCTIONS"
 
     ng-form novalidate="" name="form.signIn"
 
@@ -26,12 +22,4 @@
 
       .form-group
         p.t-small.c-steel.text-center.padding-top.no-margin
-          input.button.no-margin#sign-in type="button" data-event="gtm-sign-in" value="{{'LABEL.SIGN_IN_TO_CONTINUE' | translate}}" ng-disabled="submitDisabled" ng-click="signIn()" ng-if="!shortFormAccountExists()"
-          input.button.no-margin.primary#sign-in type="button" data-event="gtm-sign-in" value="{{'LABEL.SIGN_IN' | translate}}" ng-disabled="submitDisabled" ng-click="signIn()" ng-if="shortFormAccountExists()"
-
-
-
-  .button-pager.round.border-top ng-if="shortFormAccountExists()"
-    .button-pager_row.padding-top--2x.padding-bottom--2x
-      a#confirm_no_account.button.radius ui-sref="dahlia.short-form-application.review-terms"
-        | {{'F1A_REVIEW_SIGN_IN.CONTINUE_WITHOUT_SIGNING_IN' | translate}}
+          input.button.no-margin.secondary#sign-in type="button" data-event="gtm-sign-in" value="{{'LABEL.SIGN_IN_TO_CONTINUE' | translate}}" ng-disabled="submitDisabled" ng-click="signIn()"

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -332,12 +332,7 @@
         "TITLE": "Help us ensure we are meeting our goal to serve all people."
     },
     "F1A_REVIEW_SIGN_IN": {
-        "ACCOUNT_EXISTS": {
-            "P1": "It looks like you may already have an account. Signing in will save your information to your existing account, and allow you to check the status of this application at any time.",
-            "TITLE": "Welcome back!"
-        },
         "CONTINUE_WITHOUT_AN_ACCOUNT": "Continue without an account",
-        "CONTINUE_WITHOUT_SIGNING_IN": "Continue without signing in",
         "INSTRUCTIONS": "Signing in will save your information to your existing account, and allow you to check the status of this application at any time.",
         "TITLE": "You're almost done!"
     },

--- a/app/controllers/api/v1/account_controller.rb
+++ b/app/controllers/api/v1/account_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::AccountController < ApiController
   AccountService = SalesforceService::AccountService
   ListingService = SalesforceService::ListingService
 
-  before_action :authenticate_user!, except: %i[confirm check_account]
+  before_action :authenticate_user!, except: [:confirm]
 
   def my_applications
     applications = map_listings_to_applications(current_user_applications)
@@ -17,14 +17,6 @@ class Api::V1::AccountController < ApiController
     salesforce_contact = AccountService.create_or_update(contact)
     Emailer.account_update(current_user).deliver_later
     render json: { contact: salesforce_contact }
-  end
-
-  def check_account
-    if User.find_by_email(params[:email])
-      render json: { account_exists: true }
-    else
-      render json: { account_exists: false }
-    end
   end
 
   def confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,6 @@ Rails.application.routes.draw do
         get 'my-applications' => 'account#my_applications'
         put 'update' => 'account#update'
         get 'confirm' => 'account#confirm'
-        get 'check-account' => 'account#check_account'
       end
     end
   end

--- a/spec/requests/api/v1/account_spec.rb
+++ b/spec/requests/api/v1/account_spec.rb
@@ -29,20 +29,4 @@ describe 'Account API' do
     # check to make sure the response data is present
     expect(json['applications']).not_to be_nil
   end
-
-  describe '#check-account' do
-    it 'checks for existing user account by email address' do
-      get '/api/v1/account/check-account', email: @user.email
-      json = JSON.parse(response.body)
-      expect(response).to be_success
-      expect(json['account_exists']).to eq(true)
-    end
-
-    it 'checks for non-existing user account by email address' do
-      get '/api/v1/account/check-account', email: 'nobody@not.email'
-      json = JSON.parse(response.body)
-      expect(response).to be_success
-      expect(json['account_exists']).to eq(false)
-    end
-  end
 end

--- a/spec/support/devise_macros.rb
+++ b/spec/support/devise_macros.rb
@@ -3,9 +3,9 @@ module DeviseMacros
   def login_user
     before(:each) do
       qa_id = '0030P00001y3eLHQAY'
-      @user = User.find_by_salesforce_contact_id(qa_id)
-      @user ||= FactoryGirl.create(:user, salesforce_contact_id: qa_id)
-      token = @user.create_new_auth_token
+      user = User.find_by_salesforce_contact_id(qa_id)
+      user ||= FactoryGirl.create(:user, salesforce_contact_id: qa_id)
+      token = user.create_new_auth_token
       @auth_headers = { Accept: 'application/json' }.merge(token)
     end
   end


### PR DESCRIPTION
[#154821728] Revert "Features/full/dynamic sign in before submit #146654295 (#818)"

This reverts commit 18f70daa6963f6f6116cce1398c74127557b11e3. It was decided that the feature in story #146654295 was no longer desired because the functionality it provides has been superseded by a newer feature, story #152331095.

We no longer want to offer sign-in before submit in the short form; instead, we have created the sign-in at start of short form mini epic to provide sign-in functionality within the short form app.