### PR TITLE
Bugs/Updates locator name property for geocoding service #155663674

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
@@ -269,7 +269,7 @@ ShortFormDataService = (ListingService) ->
         data.xCoordinate = geo.location.x
         data.yCoordinate = geo.location.y
       if geo.attributes
-        data.whichComponentOfLocatorWasUsed = geo.attributes.loc_name
+        data.whichComponentOfLocatorWasUsed = geo.attributes.Loc_name
       data.candidateScore = geo.score
     return data
 


### PR DESCRIPTION
The new geocoding endpoints returns `Loc_name` rather than `loc_name`, even when
the property is requested as `loc_name`