### PR TITLE
Bugs/Live-Work opt out canceled incorrectly #155714607

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -327,8 +327,12 @@ ShortFormApplicationService = (
 
   Service.cancelOptOut = (preference) ->
     Service.application.preferences.optOut[preference] = false
-    if preference == 'neighborhoodResidence'
-      # if we cancel our NRHP Opt Out, we cancel liveWorkOptOut as well
+    # For NRHP and ADHP, if the applicant is eligible and can choose to claim the
+    # preference, we cancel Opt Out for Live/Work as well
+    if (
+      (preference == 'neighborhoodResidence' && Service.eligibleForNRHP()) ||
+      (preference == 'antiDisplacement' && Service.eligibleForADHP())
+    )
       Service.cancelOptOut('liveWorkInSf')
 
   Service.preferenceRequired = (preference) ->

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -298,8 +298,11 @@ ShortFormApplicationService = (
     Service.currentRentBurdenAddress.index = index
 
   Service.cancelPreference = (preference) ->
-    if _.includes(['neighborhoodResidence', 'antiDisplacement'], preference)
-      # cancelling Neighborhood also cancels liveInSf
+    if (
+      (preference == 'neighborhoodResidence' && Service.eligibleForNRHP()) ||
+      (preference == 'antiDisplacement' && Service.eligibleForADHP())
+    )
+      # cancelling NRHP or ADHP also cancels liveInSf
       Service.cancelPreference('liveInSf')
     if _.includes(['liveWorkInSf', 'liveInSf', 'workInSf'], preference)
       # cancels liveWork combo options

--- a/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
@@ -159,6 +159,10 @@ ShortFormDataService = (ListingService) ->
 
       if listingPref.preferenceName == PREFS.liveWorkInSf
         shortformPreferenceID = appPrefs.liveWorkInSf_shortformPreferenceID
+        # default prefKey and optOut for Live/Work, in case individual live or work
+        # preference isn't applicable (like when applicant is eligible for both, but
+        # opts out of preference all together)
+        prefKey = 'liveWorkInSf'
         optOut = appPrefs.optOut.liveWorkInSf
         if appPrefs.liveInSf || appPrefs.optOut.liveInSf
           individualPref = 'Live in SF'

--- a/spec/javascripts/services/short_form_application_service_spec.coffee
+++ b/spec/javascripts/services/short_form_application_service_spec.coffee
@@ -755,21 +755,249 @@ do ->
           expect(ShortFormApplicationService.applicant.phoneType).toEqual null
 
     describe 'cancelPreference', ->
-      beforeEach ->
+      it 'unsets preference fields', ->
+        spyOn(ShortFormApplicationService, 'unsetPreferenceFields').and.callThrough()
+
+        preference = 'certOfPreference'
+        ShortFormApplicationService.cancelPreference(preference)
+        expect(ShortFormApplicationService.unsetPreferenceFields)
+          .toHaveBeenCalledWith(preference)
+
+      describe 'cancels Live/Work', ->
+        it 'should clear Live/Work combo options if Live/Work is canceled', ->
+          ShortFormApplicationService.preferences.liveWorkInSf = true
+          ShortFormApplicationService.preferences.liveWorkInSf_preference = 'liveInSf'
+
+          ShortFormApplicationService.cancelPreference('liveWorkInSf')
+          expect(ShortFormApplicationService.preferences.liveWorkInSf).toEqual false
+          expect(ShortFormApplicationService.preferences.liveWorkInSf_preference)
+            .toEqual null
+
+        it 'should clear Live/Work combo options if Live is canceled', ->
+          ShortFormApplicationService.preferences.liveWorkInSf = true
+          ShortFormApplicationService.preferences.liveWorkInSf_preference = 'liveInSf'
+
+          ShortFormApplicationService.cancelPreference('liveInSf')
+          expect(ShortFormApplicationService.preferences.liveWorkInSf).toEqual false
+          expect(ShortFormApplicationService.preferences.liveWorkInSf_preference)
+            .toEqual null
+
+        it 'should clear Live/Work combo options if Work is canceled', ->
+          ShortFormApplicationService.preferences.liveWorkInSf = true
+          ShortFormApplicationService.preferences.liveWorkInSf_preference = 'liveInSf'
+
+          ShortFormApplicationService.cancelPreference('workInSf')
+          expect(ShortFormApplicationService.preferences.liveWorkInSf).toEqual false
+          expect(ShortFormApplicationService.preferences.liveWorkInSf_preference)
+            .toEqual null
+
+        it 'should unset individual Live and Work fields if Live/Work is canceled', ->
+          spyOn(ShortFormApplicationService, 'unsetPreferenceFields').and.callThrough()
+
+          ShortFormApplicationService.cancelPreference('liveWorkInSf')
+          expect(ShortFormApplicationService.unsetPreferenceFields)
+            .toHaveBeenCalledWith('liveInSf')
+          expect(ShortFormApplicationService.unsetPreferenceFields)
+            .toHaveBeenCalledWith('workInSf')
+
+      describe 'cancels NRHP', ->
+        beforeEach ->
+          spyOn(ShortFormApplicationService, 'cancelPreference').and.callThrough()
+
+        it 'should not clear Live in SF if listing doesn\'t have NRHP', ->
+          # Listing doesn't have NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(false)
+
+          ShortFormApplicationService.cancelPreference('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelPreference).not.toHaveBeenCalledWith('liveInSf')
+
+        it 'should not clear Live in SF if applicant not eligible for NRHP', ->
+          # Listing has NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant not eligible for NRHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Not Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelPreference('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelPreference).not.toHaveBeenCalledWith('liveInSf')
+
+          resetFakePeople()
+
+        it 'should clear Live in SF if listing has NRHP and applicant is elibible for NRHP', ->
+          # Listing has NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant is eligible for NRHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelPreference('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelPreference).toHaveBeenCalledWith('liveInSf')
+
+          resetFakePeople()
+
+      describe 'cancels ADHP', ->
+        beforeEach ->
+          spyOn(ShortFormApplicationService, 'cancelPreference').and.callThrough()
+
+        it 'should not clear Live in SF if listing doesn\'t have ADHP', ->
+          # Listing doesn't have ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(false)
+
+          ShortFormApplicationService.cancelPreference('antiDisplacement')
+          expect(ShortFormApplicationService.cancelPreference).not.toHaveBeenCalledWith('liveInSf')
+
+        it 'should not clear Live in SF if applicant not eligible for ADHP', ->
+          # Listing has ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant not eligible for ADHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Not Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelPreference('antiDisplacement')
+          expect(ShortFormApplicationService.cancelPreference).not.toHaveBeenCalledWith('liveInSf')
+
+          resetFakePeople()
+
+        it 'should clear Live in SF if listing has ADHP and applicant is elibible for ADHP', ->
+          # Listing has ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant is eligible for ADHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelPreference('antiDisplacement')
+          expect(ShortFormApplicationService.cancelPreference).toHaveBeenCalledWith('liveInSf')
+
+          resetFakePeople()
+
+    describe 'unsetPreferenceFields', ->
+      it 'should clear preference name, household member, proof option, and file', ->
         fakeFileUploadService.deletePreferenceFile = jasmine.createSpy()
         ShortFormApplicationService.preferences.liveInSf = true
         ShortFormApplicationService.preferences.liveInSf_household_member = 1
+        ShortFormApplicationService.preferences.liveInSf_proofOption = 'Telephone bill'
         ShortFormApplicationService.preferences.documents.liveInSf = {
           proofOption: 'Telephone Bill'
           file: {name: 'somefile.pdf'}
         }
 
-      it 'should clear preference name, household member, proof option and file', ->
-        ShortFormApplicationService.cancelPreference('liveInSf')
+        ShortFormApplicationService.unsetPreferenceFields('liveInSf')
         expect(ShortFormApplicationService.preferences.liveInSf).toEqual null
         expect(ShortFormApplicationService.preferences.liveInSf_household_member).toEqual null
+        expect(ShortFormApplicationService.preferences.liveInSf_proofOption).toEqual null
         listingId = ShortFormApplicationService.listing.Id
-        expect(fakeFileUploadService.deletePreferenceFile).toHaveBeenCalledWith('liveInSf', listingId)
+        expect(fakeFileUploadService.deletePreferenceFile)
+          .toHaveBeenCalledWith('liveInSf', listingId)
+
+      it 'should delete Rent Burdened preference files', ->
+        listingId = ShortFormApplicationService.listing.Id
+
+        ShortFormApplicationService.unsetPreferenceFields('rentBurden')
+        expect(fakeFileUploadService.deleteRentBurdenPreferenceFiles)
+          .toHaveBeenCalledWith(listingId)
+
+      it 'should clear COP certificate number', ->
+        ShortFormApplicationService.preferences.certOfPreference_certificateNumber =
+          '12345678'
+
+        ShortFormApplicationService.unsetPreferenceFields('certOfPreference')
+        expect(ShortFormApplicationService.preferences.certOfPreference_certificateNumber)
+          .toEqual null
+
+      it 'should clear DTHP certificate number', ->
+        ShortFormApplicationService.preferences.displaced_certificateNumber =
+          '12345678'
+
+        ShortFormApplicationService.unsetPreferenceFields('displaced')
+        expect(ShortFormApplicationService.preferences.displaced_certificateNumber)
+          .toEqual null
+
+    describe 'cancelOptOut', ->
+      it 'should clear preference opt out', ->
+        ShortFormApplicationService.preferences.optOut.liveInSf = true
+
+        ShortFormApplicationService.cancelOptOut('liveInSf')
+        expect(ShortFormApplicationService.preferences.optOut.liveInSf).toEqual false
+
+      describe 'cancel NRHP Opt Out', ->
+        beforeEach ->
+          spyOn(ShortFormApplicationService, 'cancelOptOut').and.callThrough()
+
+        it 'should not clear Live/Work Opt Out if listing doesn\'t have NRHP', ->
+          # Listing doesn't have NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(false)
+
+          ShortFormApplicationService.cancelOptOut('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelOptOut)
+            .not.toHaveBeenCalledWith('liveWorkInSf')
+
+        it 'should not clear Live/Work Opt Out if applicant not eligible for NRHP', ->
+          # Listing has NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant not eligible for NRHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Not Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelOptOut('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelOptOut)
+            .not.toHaveBeenCalledWith('liveWorkInSf')
+
+          resetFakePeople()
+
+        it 'should clear Live/Work Opt Out if listing has NRHP and elibible for NRHP', ->
+          # Listing has NRHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant is eligible for NRHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelOptOut('neighborhoodResidence')
+          expect(ShortFormApplicationService.cancelOptOut).toHaveBeenCalledWith('liveWorkInSf')
+
+          resetFakePeople()
+
+      describe 'cancel ADHP Opt Out', ->
+        beforeEach ->
+          spyOn(ShortFormApplicationService, 'cancelOptOut').and.callThrough()
+
+        it 'should not clear Live/Work Opt Out if listing doesn\'t have ADHP', ->
+          # Listing doesn't have ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(false)
+
+          ShortFormApplicationService.cancelOptOut('antiDisplacement')
+          expect(ShortFormApplicationService.cancelOptOut).not.toHaveBeenCalledWith('liveWorkInSf')
+
+        it 'should not clear Live/Work Opt Out if not eligible for ADHP', ->
+          # Listing has ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant not eligible for ADHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Not Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelOptOut('antiDisplacement')
+          expect(ShortFormApplicationService.cancelOptOut).not.toHaveBeenCalledWith('liveWorkInSf')
+
+          resetFakePeople()
+
+        it 'should clear Live/Work Opt Out if listing has ADHP and elibible for ADHP', ->
+          # Listing has ADHP
+          fakeListingService.hasPreference = jasmine.createSpy().and.returnValue(true)
+
+          # Applicant is eligible for ADHP
+          setupFakeApplicant({ preferenceAddressMatch: 'Matched' })
+          ShortFormApplicationService.applicant = fakeApplicant
+
+          ShortFormApplicationService.cancelOptOut('antiDisplacement')
+          expect(ShortFormApplicationService.cancelOptOut).toHaveBeenCalledWith('liveWorkInSf')
+
+          resetFakePeople()
 
     describe 'resetPreference', ->
       beforeEach ->


### PR DESCRIPTION
Because of the change in bed4b75 preferences that weren't being claimed were still being reset. This had a side effect of cancelling the claiming and opting out of Live/Work preference, because NRHP was always being reset before application was sent or loaded from Salesforce.

When applicant is eligible for NRHP, this is the correct behavior, because claiming NRHP also claims Live/Work, if changing address resets NRHP it should also reset Live/Work, etc. However if applicant isn't eligible for NRHP, we don't want NRHP affecting anything with Live/Work preference.

Also, ADHP resets Live/Work in the same way that NRHP does, so additional conditions are now in place to make NRHP/ADHP function in the same way.