### PR TITLE
[#157264305] Undefined Preferences Bug

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -133,6 +133,18 @@ ShortFormApplicationService = (
 
     completed = Service.application.completedSections
     validated = Service.application.validatedForms
+
+    # catch errors where validatedForms becomes undefined
+    if isEmpty(validated)
+      Raven.captureMessage('Validated forms is unexpectedly empty', {
+        level: 'warning',
+        extra: {
+          sectionName: name,
+          application: Service.application
+        }
+      })
+      return false
+
     switch name
       when 'You'
         true


### PR DESCRIPTION
After discussing with @callaghanc we decided that our best bet is to return false if validatedForms is undefined, and log some more information about the application state when that occurs. 

