### PR TITLE
[#159019798] Add logging for missing validatedForms

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -133,6 +133,15 @@ ShortFormApplicationService = (
 
     completed = Service.application.completedSections
     validated = Service.application.validatedForms
+
+    # catch errors where validatedForms becomes undefined
+    if isEmpty(validated)
+      Raven.captureMessage('Validated forms is unexpectedly empty', {
+        level: 'warning',
+        extra: { sectionName: name, application: Service.application }
+      })
+      return false
+
     switch name
       when 'You'
         true


### PR DESCRIPTION
Talked to @callaghanc and we decided that the best move for this bug is to go ahead and return false if validatedForms doesn't exist, and send some logs to sentry if that's the case. 

