### PR TITLE
[#157264305] Undefined preference errors

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -385,10 +385,13 @@ ShortFormApplicationController = (
   $scope.checkForCustomProofPreferences = ->
     nextIndex = null
     currentIndex = parseInt($state.params.prefIdx)
-    if currentIndex >= 0 && currentIndex < $scope.listing.customProofPreferences.length - 1
-      nextIndex = currentIndex + 1
-    else if isNaN(currentIndex) && $scope.listing.customProofPreferences.length
-      nextIndex = 0
+
+    if !isEmpty($scope.listing.customProofPreferences)
+      if currentIndex >= 0 && currentIndex < $scope.listing.customProofPreferences.length - 1
+        nextIndex = currentIndex + 1
+      else if isNaN(currentIndex) && $scope.listing.customProofPreferences.length
+        nextIndex = 0
+
     if nextIndex != null
       $scope.goToAndTrackFormSuccess('dahlia.short-form-application.custom-proof-preferences', {prefIdx: nextIndex})
     else

--- a/spec/javascripts/services/short_form_data_service_spec.coffee
+++ b/spec/javascripts/services/short_form_data_service_spec.coffee
@@ -1,6 +1,7 @@
 do ->
   'use strict'
   describe 'ShortFormDataService', ->
+    $q = undefined
     ShortFormDataService = undefined
     formattedApp = undefined
     reformattedApp = undefined
@@ -32,7 +33,8 @@ do ->
       return
     )
 
-    beforeEach inject((_ShortFormDataService_) ->
+    beforeEach inject((_$q_, _ShortFormDataService_) ->
+      $q = _$q_
       ShortFormDataService = _ShortFormDataService_
       return
     )
@@ -49,6 +51,15 @@ do ->
 
       it 'sends stringified JSON for formMetadata', ->
         expect(formattedApp.formMetadata).toContain('"completedSections"')
+
+      describe 'formatApplication when listing preferences are missing', ->
+        beforeEach ->
+          fakeListingService.listing.preferences = null
+          fakeListingService.getListingPreferences = jasmine.createSpy().and.returnValue($q.defer().promise)
+          formattedApp = ShortFormDataService.formatApplication(fakeListingId, fakeApplication)
+
+        it 'calls ListingService.getListingPreferences', ->
+          expect(fakeListingService.getListingPreferences).toHaveBeenCalled()
 
     describe 'reformatApplication', ->
       beforeEach ->


### PR DESCRIPTION
Fixes here:

### 1. Handled customProofPreferences length bug
If customProofPreferences are undefined, we assume that there are none and continue

### 2. If listing preferences are undefined when formatApplication is called (generally on save)
Then we call getListingPreferences again and wait for listing preferences to be filled in before returning the formatted application,
