### PR TITLE
Chores/undefined preference errors #157264305

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -386,7 +386,7 @@ ShortFormApplicationController = (
     nextIndex = null
     currentIndex = parseInt($state.params.prefIdx)
 
-    if !isEmpty($scope.listing.customProofPreferences)
+    if !_.isEmpty($scope.listing.customProofPreferences)
       if currentIndex >= 0 && currentIndex < $scope.listing.customProofPreferences.length - 1
         nextIndex = currentIndex + 1
       else if isNaN(currentIndex) && $scope.listing.customProofPreferences.length

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -385,10 +385,13 @@ ShortFormApplicationController = (
   $scope.checkForCustomProofPreferences = ->
     nextIndex = null
     currentIndex = parseInt($state.params.prefIdx)
-    if currentIndex >= 0 && currentIndex < $scope.listing.customProofPreferences.length - 1
-      nextIndex = currentIndex + 1
-    else if isNaN(currentIndex) && $scope.listing.customProofPreferences.length
-      nextIndex = 0
+
+    if !isEmpty($scope.listing.customProofPreferences)
+      if currentIndex >= 0 && currentIndex < $scope.listing.customProofPreferences.length - 1
+        nextIndex = currentIndex + 1
+      else if isNaN(currentIndex) && $scope.listing.customProofPreferences.length
+        nextIndex = 0
+
     if nextIndex != null
       $scope.goToAndTrackFormSuccess('dahlia.short-form-application.custom-proof-preferences', {prefIdx: nextIndex})
     else

--- a/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormDataService.js.coffee
@@ -83,17 +83,8 @@ ShortFormDataService = (ListingService) ->
     sfApp.formMetadata = Service._formatMetadata(application)
 
     # add preferences and return
-    if !ListingService.listing.preferences
-      # if listing preferences are not present when they should be, fetch them again
-      Raven.captureMessage('Undefined listing preferences', {
-        level: 'warning', extra: { listing: ListingService.listing }
-      })
-      ListingService.getListingPreferences().then ->
-        sfApp.shortFormPreferences = Service._formatPreferences(application)
-        return sfApp
-    else
-      sfApp.shortFormPreferences = Service._formatPreferences(application)
-      return sfApp
+    sfApp.shortFormPreferences = Service._formatPreferences(application)
+    return sfApp
 
   Service.formatUserDOB = (user) ->
     dob_fields = _.compact [user.dob_year, user.dob_month, user.dob_day]

--- a/spec/javascripts/services/short_form_data_service_spec.coffee
+++ b/spec/javascripts/services/short_form_data_service_spec.coffee
@@ -1,7 +1,6 @@
 do ->
   'use strict'
   describe 'ShortFormDataService', ->
-    $q = undefined
     ShortFormDataService = undefined
     formattedApp = undefined
     reformattedApp = undefined
@@ -33,8 +32,7 @@ do ->
       return
     )
 
-    beforeEach inject((_$q_, _ShortFormDataService_) ->
-      $q = _$q_
+    beforeEach inject((_ShortFormDataService_) ->
       ShortFormDataService = _ShortFormDataService_
       return
     )
@@ -51,15 +49,6 @@ do ->
 
       it 'sends stringified JSON for formMetadata', ->
         expect(formattedApp.formMetadata).toContain('"completedSections"')
-
-      describe 'formatApplication when listing preferences are missing', ->
-        beforeEach ->
-          fakeListingService.listing.preferences = null
-          fakeListingService.getListingPreferences = jasmine.createSpy().and.returnValue($q.defer().promise)
-          formattedApp = ShortFormDataService.formatApplication(fakeListingId, fakeApplication)
-
-        it 'calls ListingService.getListingPreferences', ->
-          expect(fakeListingService.getListingPreferences).toHaveBeenCalled()
 
     describe 'reformatApplication', ->
       beforeEach ->

--- a/spec/javascripts/services/short_form_data_service_spec.coffee
+++ b/spec/javascripts/services/short_form_data_service_spec.coffee
@@ -1,6 +1,7 @@
 do ->
   'use strict'
   describe 'ShortFormDataService', ->
+    $q = undefined
     ShortFormDataService = undefined
     formattedApp = undefined
     reformattedApp = undefined
@@ -32,7 +33,8 @@ do ->
       return
     )
 
-    beforeEach inject((_ShortFormDataService_) ->
+    beforeEach inject((_$q_, _ShortFormDataService_) ->
+      $q = _$q_
       ShortFormDataService = _ShortFormDataService_
       return
     )
@@ -49,6 +51,15 @@ do ->
 
       it 'sends stringified JSON for formMetadata', ->
         expect(formattedApp.formMetadata).toContain('"completedSections"')
+
+      describe 'formatApplication when listing preferences are missing', ->
+        beforeEach ->
+          fakeListingService.listing.preferences = null
+          fakeListingService.getListingPreferences = jasmine.createSpy().and.returnValue($q.defer().promise)
+          formattedApp = ShortFormDataService.formatApplication(fakeListingId, fakeApplication)
+
+        it 'calls ListingService.getListingPreferences', ->
+          expect(fakeListingService.getListingPreferences).toHaveBeenCalled()
 
     describe 'reformatApplication', ->
       beforeEach ->

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -13,3 +13,8 @@
 #    config.prevent_phantom_js_auto_install = true
 # end
 #
+
+# Uncomment lines below to show logs for Jasmine tests.
+# Jasmine.configure do |config|
+#  config.show_console_log = true
+# end


### PR DESCRIPTION
Fixes here:

### 1. Handled customProofPreferences length bug
If customProofPreferences are undefined, we assume that there are none and continue

### 2. If listing preferences are undefined when formatApplication is called (generally on save)
Then we call getListingPreferences again and wait for listing preferences to be filled in before returning the formatted application,