### PR TITLE
Chores/update overcommit coffeelint #162065874

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -44,8 +44,9 @@ PreCommit:
   CoffeeLint:
     enabled: true
     description: 'Analyzing with CoffeeLint'
-    required_executable: 'coffeelint'
     install_command: 'npm install'
+    required_executable: 'npm'
+    command: ['npm', 'run', 'coffeelint']
 
   TrailingWhitespace:
     enabled: true


### PR DESCRIPTION
The previous Coffeelint configuration in overcommit.yml was not working for me - Overcommit would throw an error when I ran it and it reached the stage where it tried to run Coffeelint. I used the information in this Overcommit GitHub issue: https://github.com/brigade/overcommit/issues/352, to update the configuration to something that worked without error.