### PR TITLE
#160152697 - Redirect Plus Housing page, add magic comment to application.rb

### DIFF
--- a/app/views/home/plus-housing.html.slim
+++ b/app/views/home/plus-housing.html.slim
@@ -1,21 +1,2 @@
-header#pub_banner.pub_banner role="banner"
-  .container
-    .pub_banner_info
-      span.pub_banner_context
-        a href="/"
-          span City and County of San Francisco
-      .pub_banner_title
-        h1.pub_banner_text MOHCD +Housing application
-        #google_translate_element
-        ul.pub_banner_actions
-
-form data-formrenderer=""  This form requires JavaScript to complete.
-small style="display:inline-block;margin-top:10px;background:rgba(0,0,0,0.1);padding:5px 10px;border-radius:10px;"
-  | Powered by
-  a href="https://www.dobt.co/screendoor/"  Screendoor
-  | .
-javascript:
-  // Uncomment this line and set it to the CSS class that your website uses for buttons:
-  // FormRenderer.BUTTON_CLASS = 'button'
-
-  new FormRenderer({"project_id":"77CGiHj1iT9QlTNo"});
+a href="https://sfmohcd.org/plus-housing-application"
+  | Click here if you are not redirected.

--- a/app/views/layouts/plus-housing.html.slim
+++ b/app/views/layouts/plus-housing.html.slim
@@ -5,47 +5,7 @@ doctype html
 html lang="en"
   /! <![endif]
   head
-    title +Housing
-    javascript:
-      window.jQuery || document.write('<script src="//code.jquery.com/jquery-2.2.3.min.js"><\/script>')
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
-      }
-
-    link href="//d3q1ytufopwvkq.cloudfront.net/1/formrenderer.css" rel="stylesheet"
-    / css pulled from https://sfgov.forms.fm/mohcd-plus-housing-application/responses/new
-    link href="https://d3bt6306j428ad.cloudfront.net/assets/respondent_view-7988ec2ee87f5c73bdb9135ca4a95e3db56eb37eedaeac29a0d154d82b2a798e.css" rel="stylesheet"
-    script src="//d3q1ytufopwvkq.cloudfront.net/1/formrenderer.js"
-    script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" type="text/javascript"
-
-    / inline CSS so we don't have to deal with it in asset pipeline + application.css
-    css:
-      .fr_response_field {margin-bottom:10px!important;}
-      form input, form select {background:#e9e9e9;padding:12px 13px 10px 13px;border:0;}
-      form select {padding:13px 0;}
-      .fr_response_field label {width:100%;padding:1.2em 0 10px; font-size:18px; line-height:1.4em;color:#3d3d3d;z-index:1;font-weight:normal;}
-      .has_sub_label label {padding-top:0;line-height:1.4em;font-size:14px;}
-      .fr_response_field_number .fr_units, .fr_grid .fr_spacer {font-size:16px!important;}
-      .fr_response_field_section_break {margin:5em 0 0;}
-      .fr_page .fr_response_field_section_break:first-of-type {margin:0;}
-      form hr {margin:5px;}
-      label.fr_option {padding:5px 0 5px 20px;text-indent:-18px;}
-      .fr_bottom {background:#fff!important;color:#888;font-size:18px;}
-      .fr_button {background:#0085d0; color:#fff!important;line-height:54px !important;padding:0 30px !important;width:auto!important;transition:background 0.3s;}
-      .fr_button:hover, .fr_button:focus {background:#054a71;}
-      abbr[title], .fr_required {text-decoration:none;border-bottom:0;}
-      input#c44 {width:auto!important;}
-      #fr_response_field_sydee3yw {padding-top:1em;}
-      form {max-width:900px;display:block;margin:0 auto;}
-
-      /*overwrites*/
-      a { background-image: none; }
-      label.control input {
-        position: relative;
-        opacity: 100;
-      }
-      .fr_option.control { padding: 5px 0 5px 0px; }
-
-
+    title SFMOHCD Plus Housing
+    link href="https://sfmohcd.org/plus-housing-application" rel="canonical"
   body
     = yield

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
@@ -52,6 +54,7 @@ module SfDahliaWeb
     config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
       r301 %r{(.+)/$}, '$1'
       r301 %r{(.+)/\?(.*)$}, '$1?$2'
+      r301 '/mohcd-plus-housing', 'https://sfmohcd.org/plus-housing-application'
     end
   end
 end


### PR DESCRIPTION
This PR:

1. Adds a 301 redirect to the Plus Housing form on SFMOHCD.org
2. Replaces the Plus Housing page with a link to the new page and a `link rel=canonical` tag, in the event the 301 fails for whatever reason
3. Adds the "magic comment" `# frozen_string_literal: true` to `application.rb`, which Overcommit required me to do

I don't really understand what 3) does, so it would be great if I could get a +1 from someone more knowledgeable!