### PR TITLE
Fix failing jasmine tests for ExternalTranslateService #164937511

### DIFF
--- a/spec/javascripts/services/external_translate_service_spec.coffee
+++ b/spec/javascripts/services/external_translate_service_spec.coffee
@@ -102,6 +102,9 @@ do ->
           expect(ExternalTranslateService.language).toEqual('es')
 
     describe 'translatePageContent', ->
+      beforeEach ->
+        ExternalTranslateService.init = jasmine.createSpy()
+
       it 'attempts to find the external translate widget DOM element that corresponds to Service.language', ->
         spyOn(document, 'querySelector')
         ExternalTranslateService.language = 'es'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164937511

Our Prod semaphore job doesn't run jasmine tests, which is why I missed this issue. 