### PR TITLE
Upgrade Jasmine and fix failing tests #165609939

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development, :test do
   gem 'awesome_print'
   gem 'dotenv-rails'
   gem 'jquery-rails' # only needed for jasmine-jquery
-  gem 'jasmine', github: 'pivotal/jasmine-gem'
+  gem 'jasmine'
   gem 'jasmine-jquery-rails' # used for functions like `getJSONFixture`
   gem 'phantomjs', '~> 2.1.1'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,16 +18,6 @@ GIT
   specs:
     StreetAddress (2.0.0)
 
-GIT
-  remote: https://github.com/pivotal/jasmine-gem.git
-  revision: cf6416adaba04549b83d9faa97479c431773b884
-  specs:
-    jasmine (3.4.0)
-      jasmine-core (~> 3.4.0)
-      phantomjs
-      rack (>= 1.2.1)
-      rake
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -185,6 +175,11 @@ GEM
     image_optimizer (1.7.0)
     iniparse (1.4.2)
     ipaddress (0.8.3)
+    jasmine (3.4.0)
+      jasmine-core (~> 3.4.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
     jasmine-core (3.4.0)
     jasmine-jquery-rails (2.0.3)
     jbuilder (2.8.0)
@@ -425,7 +420,7 @@ DEPENDENCIES
   heroku-deflater!
   http
   image_optimizer (~> 1.7.0)
-  jasmine!
+  jasmine
   jasmine-jquery-rails
   jbuilder (~> 2.8.0)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ GIT
 
 GIT
   remote: https://github.com/pivotal/jasmine-gem.git
-  revision: cbdad51e5b203e82ed47f09909063994823cc20a
+  revision: cf6416adaba04549b83d9faa97479c431773b884
   specs:
-    jasmine (2.6.0)
-      jasmine-core (>= 2.6.0, < 3.0.0)
+    jasmine (3.4.0)
+      jasmine-core (~> 3.4.0)
       phantomjs
       rack (>= 1.2.1)
       rake
@@ -185,7 +185,7 @@ GEM
     image_optimizer (1.7.0)
     iniparse (1.4.2)
     ipaddress (0.8.3)
-    jasmine-core (2.6.1)
+    jasmine-core (3.4.0)
     jasmine-jquery-rails (2.0.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)

--- a/app/assets/javascripts/config/angularModules.js.coffee
+++ b/app/assets/javascripts/config/angularModules.js.coffee
@@ -7,11 +7,11 @@ angular.module('dahlia.components', [])
 
 # Raven must be configured before including `ngRaven` module below
 # SENTRY_JS_URL is defined globally in application.html.slim
-Raven
-  .config(SENTRY_JS_URL)
-  .addPlugin(Raven.Plugins.Angular)
-  .install()
-
+if SENTRY_JS_URL?
+  Raven
+    .config(SENTRY_JS_URL)
+    .addPlugin(Raven.Plugins.Angular)
+    .install()
 
 @dahlia = angular.module 'dahlia', [
   'dahlia.directives',

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -561,7 +561,7 @@ ShortFormApplicationController = (
     if match == 'incomeMatch' && $scope.application.householdVouchersSubsidies == 'Yes'
       ShortFormNavigationService.goToSection('Preferences')
       return
-    ShortFormApplicationService.checkHouseholdEligiblity($scope.listing)
+    ShortFormApplicationService.checkHouseholdEligibility($scope.listing)
       .then( (response) ->
         eligibility = response.data
         if match == 'householdMatch'

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -423,7 +423,7 @@ ShortFormApplicationService = (
     else
       'workInSf'
 
-  Service.checkHouseholdEligiblity = (listing) ->
+  Service.checkHouseholdEligibility = (listing) ->
     params =
       listing_id: listing.Id,
       eligibility:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w[jquery.js jasmine-jquery.js]

--- a/spec/javascripts/components/file_uploader_spec.coffee
+++ b/spec/javascripts/components/file_uploader_spec.coffee
@@ -41,18 +41,23 @@ do ->
       ctrl = $componentController 'fileUploader', locals, fakeBindings
 
     describe 'validateFile', ->
-      it 'should return true is file is OK', ->
+      it 'should return true if file is OK', ->
         expect(ctrl.validateFile(fakeFile)).toEqual(true)
+
       it 'should return an error if file is missing', ->
         ctrl.validateFile(null)
         expect(fakeBindings.document.error).toEqual('ERROR.FILE_MISSING')
+
       it 'should return an error if file is too big', ->
-        fakeFile.size = fakeFileUploadService.maxFileSizeBytes + 1
-        ctrl.validateFile(fakeFile)
+        tooBigFile = angular.copy(fakeFile)
+        tooBigFile.size = fakeFileUploadService.maxFileSizeBytes + 1
+        ctrl.validateFile(tooBigFile)
         expect(fakeBindings.document.error).toEqual('ERROR.FILE_UPLOAD')
+
       it 'should return an error if file name is too long', ->
-        fakeFile.name = _.repeat('a', fakeFileUploadService.maxFileNameLength + 1)
-        ctrl.validateFile(fakeFile)
+        tooLongNameFile = angular.copy(fakeFile)
+        tooLongNameFile.name = _.repeat('a', fakeFileUploadService.maxFileNameLength + 1)
+        ctrl.validateFile(tooLongNameFile)
         expect(fakeBindings.document.error).toEqual('ERROR.FILE_NAME_TOO_LONG')
 
     describe 'hasFile', ->

--- a/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
+++ b/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
@@ -52,12 +52,16 @@ do ->
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets')
           ctrl.showDownloadLotteryResultsButton()
           expect(fakeListingLotteryService.listingHasLotteryBuckets).toHaveBeenCalled()
+
         it 'returns false if listing has buckets', ->
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(true)
           expect(ctrl.showDownloadLotteryResultsButton()).toEqual false
+
         it 'returns true if listing is missing buckets', ->
+          fakeListingLotteryService.loading.lotteryResults = false
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(false)
           expect(ctrl.showDownloadLotteryResultsButton()).toEqual true
+
         it 'returns false if loading', ->
           fakeListingLotteryService.loading.lotteryResults = true
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(false)

--- a/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
+++ b/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
@@ -37,7 +37,7 @@ do ->
           expect(fakeListingLotteryService.listingHasLotteryResults).toHaveBeenCalled()
 
       describe 'openLotteryResultsModal', ->
-        it 'expect ListingLotteryService.openLotteryResultsModal to be called', ->
+        it 'calls ListingLotteryService.openLotteryResultsModal', ->
           ctrl.openLotteryResultsModal()
           expect(fakeListingLotteryService.openLotteryResultsModal).toHaveBeenCalled()
 
@@ -48,21 +48,20 @@ do ->
           expect(fakeListingLotteryService.listingHasLotteryBuckets).toHaveBeenCalled()
 
       describe '$ctrl.showDownloadLotteryResultsButton', ->
-        it 'calls ListingLotteryService.listingHasLotteryBuckets', ->
-          spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets')
-          ctrl.showDownloadLotteryResultsButton()
-          expect(fakeListingLotteryService.listingHasLotteryBuckets).toHaveBeenCalled()
-
         it 'returns false if listing has buckets', ->
+          fakeListingLotteryService.loading.lotteryResults = false
+          fakeParent.listing.LotteryResultsURL = 'foo'
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(true)
           expect(ctrl.showDownloadLotteryResultsButton()).toEqual false
 
         it 'returns true if listing is missing buckets', ->
           fakeListingLotteryService.loading.lotteryResults = false
+          fakeParent.listing.LotteryResultsURL = 'foo'
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(false)
           expect(ctrl.showDownloadLotteryResultsButton()).toEqual true
 
         it 'returns false if loading', ->
           fakeListingLotteryService.loading.lotteryResults = true
+          fakeParent.listing.LotteryResultsURL = 'foo'
           spyOn(fakeListingLotteryService, 'listingHasLotteryBuckets').and.returnValue(false)
           expect(ctrl.showDownloadLotteryResultsButton()).toEqual false

--- a/spec/javascripts/components/listing/panelApply_spec.coffee
+++ b/spec/javascripts/components/listing/panelApply_spec.coffee
@@ -54,6 +54,7 @@ do ->
 
       describe '$ctrl.submittedApplication', ->
         it 'returns true if application is submitted', ->
+          fakeApplication.status = 'submitted'
           expect(ctrl.submittedApplication()).toEqual true
         it 'returns false if application is not submitted', ->
           fakeApplication.status = 'any'

--- a/spec/javascripts/components/listingContainer_spec.coffee
+++ b/spec/javascripts/components/listingContainer_spec.coffee
@@ -277,9 +277,11 @@ do ->
           expect(fakeListingUnitService.listingHasSROUnits).toHaveBeenCalledWith(fakeListing)
 
       describe '$ctrl.agentInfoAvailable', ->
-        it 'returns undefined if agents info is not available', ->
+        it 'returns undefined if agent\'s info is not available', ->
+          fakeListing.Leasing_Agent_Street = undefined
           expect(ctrl.agentInfoAvailable(fakeListing)).not.toBeDefined()
-        it 'returns defined object if agents info is available', ->
+
+        it 'returns defined object if agent\'s info is available', ->
           fakeListing.Leasing_Agent_Street = '1 South Van Ness Ave San Francisco CA 94131'
           expect(ctrl.agentInfoAvailable(fakeListing)).toBeDefined()
 

--- a/spec/javascripts/components/preference_proof_uploader_spec.coffee
+++ b/spec/javascripts/components/preference_proof_uploader_spec.coffee
@@ -57,16 +57,21 @@ do ->
       ctrl = $componentController 'preferenceProofUploader', locals, fakeBindings
 
     describe 'validateFileNameLength', ->
-      it 'should return true is file is OK', ->
+      it 'should return true if file is OK', ->
         expect(ctrl.validateFileNameLength(fakeFile)).toEqual(true)
+
       it 'should return an error if file is missing', ->
         ctrl.validateFileNameLength(null)
         expect(fakeBindings.proofDocument.error).toEqual('ERROR.FILE_MISSING')
+
       it 'should return an error if file is too big', ->
-        fakeFile.size = fakeFileUploadService.maxFileSizeBytes + 1
-        ctrl.validateFileNameLength(fakeFile)
+        tooBigFile = angular.copy(fakeFile)
+        tooBigFile.size = fakeFileUploadService.maxFileSizeBytes + 1
+        ctrl.validateFileNameLength(tooBigFile)
         expect(fakeBindings.proofDocument.error).toEqual('ERROR.FILE_UPLOAD')
+
       it 'should return an error if file name is too long', ->
-        fakeFile.name = _.repeat('a', fakeFileUploadService.maxFileNameLength + 1)
-        ctrl.validateFileNameLength(fakeFile)
+        tooLongNameFile = angular.copy(fakeFile)
+        tooLongNameFile.name = _.repeat('a', fakeFileUploadService.maxFileNameLength + 1)
+        ctrl.validateFileNameLength(tooLongNameFile)
         expect(fakeBindings.proofDocument.error).toEqual('ERROR.FILE_NAME_TOO_LONG')

--- a/spec/javascripts/components/propertyCard_spec.coffee
+++ b/spec/javascripts/components/propertyCard_spec.coffee
@@ -12,7 +12,6 @@ do ->
     fakeSharedService = {
       showSharing: jasmine.createSpy()
     }
-    fakeListing.reservedDescriptor = [{name: 'fake'}, {name: 'not'}]
     fakeListingContainer = {
       listing: fakeListing
       hasEligibilityFilters: () -> null
@@ -119,13 +118,15 @@ do ->
 
       describe '$ctrl.reservedForLabels', ->
         it 'calls ListingDataService.reservedLabel', ->
-          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('fake')
+          fakeListing.reservedDescriptor = [{name: 'foo'}, {name: 'bar'}]
+          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('foo')
           ctrl.reservedForLabels(fakeListing)
           expect(fakeListingDataService.reservedLabel).toHaveBeenCalled()
         it 'returns values joined with or', ->
-          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('fake')
-          expect(ctrl.reservedForLabels(fakeListing)).toEqual 'fake or fake'
+          fakeListing.reservedDescriptor = [{name: 'foo'}, {name: 'bar'}]
+          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('foo')
+          expect(ctrl.reservedForLabels(fakeListing)).toEqual 'foo or foo'
         it 'returns empty string for empty reservedDescriptor', ->
           fakeListing.reservedDescriptor = null
-          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('fake')
+          spyOn(fakeListingDataService, 'reservedLabel').and.returnValue('foo')
           expect(ctrl.reservedForLabels(fakeListing)).toEqual ''

--- a/spec/javascripts/components/propertyCard_spec.coffee
+++ b/spec/javascripts/components/propertyCard_spec.coffee
@@ -83,10 +83,15 @@ do ->
             expect(ctrl.isClosedListing(fakeListing)).toEqual true
 
       describe '$ctrl.isLotteryResultsListing', ->
-        describe 'lottery results listing', ->
+        describe 'when the given listing is in the list of lottery results listings', ->
           it 'returns true',->
             fakeListingContainer.lotteryResultsListings = [fakeListing]
             expect(ctrl.isLotteryResultsListing(fakeListing)).toEqual true
+
+        describe 'when the given listing is not in the list of lottery results listings', ->
+          it 'returns true',->
+            fakeListingContainer.lotteryResultsListings = [{id: 12345}]
+            expect(ctrl.isLotteryResultsListing(fakeListing)).toEqual false
 
       describe '$ctrl.showSharing', ->
         it 'calls SharedService.showSharing', ->

--- a/spec/javascripts/controllers/account_controller_spec.coffee
+++ b/spec/javascripts/controllers/account_controller_spec.coffee
@@ -231,17 +231,19 @@ do ->
 
     describe '$scope.isSale', ->
       it 'calls ListingIdentityService.isSale', ->
-        spyOn(fakeListingIdentityService, 'isSale')
+        fakeListingIdentityService.isSale = jasmine.createSpy()
         scope.isSale(fakeListing)
         expect(fakeListingIdentityService.isSale).toHaveBeenCalled()
 
     describe '$scope.hasSaleAndRentalApplications', ->
       it 'calls ListingIdentityService.isSale', ->
-        spyOn(fakeListingIdentityService, 'isSale')
+        fakeListingIdentityService.isSale = jasmine.createSpy()
         scope.hasSaleAndRentalApplications([fakeApplication])
         expect(fakeListingIdentityService.isSale).toHaveBeenCalled()
+
       it 'returns false if there are no applications', ->
         expect(scope.hasSaleAndRentalApplications([])).toEqual(false)
+
       it 'returns true if there are at least two different applications', ->
         fakeListingIdentityService.isSale = jasmine.createSpy().and.returnValues(false, true)
         expect(scope.hasSaleAndRentalApplications([fakeApplication, fakeApplication])).toEqual(true)

--- a/spec/javascripts/controllers/account_controller_spec.coffee
+++ b/spec/javascripts/controllers/account_controller_spec.coffee
@@ -248,10 +248,13 @@ do ->
 
     describe '$scope.validatePasswordConfirmationMatch', ->
       it 'returns false if password is empty', ->
+        fakeAccountService.userAuth.user.password = ''
         expect(scope.validatePasswordConfirmationMatch('password')).toEqual(false)
+
       it 'returns false if password and confirmation does not match', ->
         fakeAccountService.userAuth.user.password = 'password'
         expect(scope.validatePasswordConfirmationMatch('pass')).toEqual(false)
+
       it 'returns true if password and confirmation match', ->
         fakeAccountService.userAuth.user.password = 'password'
         expect(scope.validatePasswordConfirmationMatch('password')).toEqual(true)

--- a/spec/javascripts/controllers/short_form_application_controller_spec.coffee
+++ b/spec/javascripts/controllers/short_form_application_controller_spec.coffee
@@ -87,7 +87,7 @@ do ->
         { error: -> null }
       validateApplicantAddress: ->
         { error: -> null }
-      checkHouseholdEligiblity: (listing) ->
+      checkHouseholdEligibility: (listing) ->
       hasHouseholdPublicHousingQuestion: ->
       submitApplication: (options={}) ->
       listingHasPreference: ->
@@ -175,7 +175,7 @@ do ->
       spyOn(fakeAccountService, 'signOut').and.returnValue(deferred.promise)
       spyOn(fakeRentBurdenFileService, 'deleteRentBurdenPreferenceFiles').and.returnValue(deferred.promise)
       spyOn(fakeAddressValidationService, 'validate').and.returnValue(deferred.promise)
-      spyOn(fakeShortFormApplicationService, 'checkHouseholdEligiblity').and.returnValue(deferred.promise)
+      spyOn(fakeShortFormApplicationService, 'checkHouseholdEligibility').and.returnValue(deferred.promise)
       spyOn(fakeShortFormApplicationService, 'keepCurrentDraftApplication').and.returnValue(deferred.promise)
       spyOn(fakeShortFormApplicationService, 'validateApplicantAddress').and.callThrough()
       spyOn(fakeShortFormApplicationService, 'validateHouseholdMemberAddress').and.callThrough()
@@ -409,10 +409,10 @@ do ->
         scope.eligibilityErrors = ['Error']
         scope.validateHouseholdEligibility()
         expect(scope.eligibilityErrors).toEqual([])
-      it 'calls checkHouseholdEligiblity in ShortFormApplicationService', ->
+      it 'calls checkHouseholdEligibility in ShortFormApplicationService', ->
         scope.listing = fakeListing
         scope.validateHouseholdEligibility('householdMatch')
-        expect(fakeShortFormApplicationService.checkHouseholdEligiblity).toHaveBeenCalledWith(fakeListing)
+        expect(fakeShortFormApplicationService.checkHouseholdEligibility).toHaveBeenCalledWith(fakeListing)
       it 'skips ahead if incomeMatch and vouchers', ->
         scope.listing = fakeListing
         scope.application.householdVouchersSubsidies = 'Yes'
@@ -549,7 +549,7 @@ do ->
         describe 'when household is eligible for Rent Burdened preference', ->
           it 'uses ShortFormNavigationService.goToApplicationPage to navigate to the Rent Burdened preference', ->
             fakeShortFormApplicationService.eligibleForAssistedHousing = jasmine.createSpy().and.returnValue(false)
-            fakeShortFormApplicationService.eligibleForRentBurden = jasmine.createSpy().and.returnValue(true)
+            spyOn(fakeShortFormApplicationService, 'eligibleForRentBurden').and.returnValue(true)
             scope.checkIfPreferencesApply()
             path = 'dahlia.short-form-application.rent-burdened-preference'
             expect(fakeShortFormNavigationService.goToApplicationPage).toHaveBeenCalledWith(path)
@@ -557,7 +557,7 @@ do ->
         describe 'when household is not eligible for Rent Burdened preference', ->
           it 'calls $scope.checkForNeighborhoodOrLiveWork()', ->
             fakeShortFormApplicationService.eligibleForAssistedHousing = jasmine.createSpy().and.returnValue(false)
-            fakeShortFormApplicationService.eligibleForRentBurden = jasmine.createSpy().and.returnValue(false)
+            spyOn(fakeShortFormApplicationService, 'eligibleForRentBurden').and.returnValue(false)
             scope.checkForNeighborhoodOrLiveWork = jasmine.createSpy()
             scope.checkIfPreferencesApply()
             expect(scope.checkForNeighborhoodOrLiveWork).toHaveBeenCalled()

--- a/spec/javascripts/services/account_service_spec.coffee
+++ b/spec/javascripts/services/account_service_spec.coffee
@@ -177,6 +177,7 @@ do ->
       afterEach ->
         httpBackend.verifyNoOutstandingExpectation()
         httpBackend.verifyNoOutstandingRequest()
+
       it 'assigns an email success message', ->
         AccountService.userAuth =
           user:
@@ -185,18 +186,13 @@ do ->
         AccountService.updateAccount('email')
         httpBackend.flush()
         expect(AccountService.accountSuccess.messages.email).not.toEqual null
+
       it 'assigns new name/DOB attributes after update', ->
         AccountService.userAuth = angular.copy(fakeUserAuth)
         stubAngularAjaxRequest httpBackend, requestURL, fakeUpdateResponse
         AccountService.updateAccount('nameDOB')
         httpBackend.flush()
         expect(AccountService.loggedInUser.firstName).toEqual fakeUpdateResponse.contact.firstName
-      it 'triggers loading overlay', ->
-        AccountService.userAuth = angular.copy(fakeUserAuth)
-        stubAngularAjaxRequest httpBackend, requestURL, fakeUpdateResponse
-        AccountService.updateAccount('nameDOB')
-        httpBackend.flush()
-        expect(fakeLoadingOverlayService.start).toHaveBeenCalled()
 
     describe 'openConfirmEmailModal', ->
       describe 'account just created', ->

--- a/spec/javascripts/services/autosave_service_spec.coffee
+++ b/spec/javascripts/services/autosave_service_spec.coffee
@@ -25,11 +25,13 @@ do ->
         expect(fakeShortFormApplicationService.submitApplication).toHaveBeenCalledWith({autosave: true})
 
     describe 'Service.startTimer', ->
-      beforeEach ->
+      beforeEach (done) ->
         AutosaveService.startTimer()
+        done()
 
       it 'creates the autosave timer', ->
         expect(AutosaveService.timer).not.toEqual(null)
+
       it 'calls submitApplication after 1 minute', ->
         spyOn(fakeShortFormApplicationService, 'submitApplication')
         $interval.flush(1000) # move forward 1 second

--- a/spec/javascripts/services/external_translate_service_spec.coffee
+++ b/spec/javascripts/services/external_translate_service_spec.coffee
@@ -9,6 +9,8 @@ do ->
     $timeout = jasmine.createSpy()
     callbackFunction = undefined
     promise = undefined
+    dummyScriptElement = document.createElement('script')
+    dummyHeadElement = document.createElement('head')
 
     beforeEach module('dahlia.services', ($provide) ->)
 
@@ -81,14 +83,21 @@ do ->
         expect(promise.constructor.name).toEqual('Promise')
 
     describe 'loadScript', ->
-      it 'appends a script tag with the external translation JS URL as src to the page head', ->
-        ExternalTranslateService.URL = 'https://google.com'
+      beforeEach ->
+        spyOn(document, 'createElement').and.returnValue(dummyScriptElement)
+        spyOn(document, 'getElementsByTagName').and.returnValue([dummyHeadElement])
+        ExternalTranslateService.URL = 'foo'
+
+      afterEach ->
+        ExternalTranslateService.URL = null
+
+      it 'adds a script tag with the service\'s URL to the page head', ->
         ExternalTranslateService.loadScript()
-        head = document.getElementsByTagName('head')[0]
-        translateScriptTag = _.find(head.childNodes, (node) ->
-          node.tagName && node.tagName.toLowerCase() == 'script' && node.getAttribute('src') == ExternalTranslateService.URL
-        )
-        expect(typeof translateScriptTag).not.toEqual('undefined')
+        expect(dummyHeadElement.childNodes[0]).toBe(dummyScriptElement)
+        expect(dummyHeadElement.childNodes[0].getAttribute('type'))
+          .toEqual('text/javascript')
+        expect(dummyHeadElement.childNodes[0].getAttribute('src'))
+          .toEqual(ExternalTranslateService.URL)
 
     describe 'setLanguage', ->
       describe 'if the given language is "zh"', ->

--- a/spec/javascripts/services/external_translate_service_spec.coffee
+++ b/spec/javascripts/services/external_translate_service_spec.coffee
@@ -82,7 +82,7 @@ do ->
 
     describe 'loadScript', ->
       it 'appends a script tag with the external translation JS URL as src to the page head', ->
-        ExternalTranslateService.URL = 'http://foo.com/bar.js'
+        ExternalTranslateService.URL = 'https://google.com'
         ExternalTranslateService.loadScript()
         head = document.getElementsByTagName('head')[0]
         translateScriptTag = _.find(head.childNodes, (node) ->
@@ -144,6 +144,7 @@ do ->
 
         it 'dispatches a change event to the element', ->
           # WIP
+          $window.Event = jasmine.createSpy().and.returnValue(changeEvent)
           ExternalTranslateService.translatePageContent()
           expect(element.dispatchEvent).toHaveBeenCalledWith(changeEvent)
 

--- a/spec/javascripts/services/file_upload_service_spec.coffee
+++ b/spec/javascripts/services/file_upload_service_spec.coffee
@@ -172,18 +172,18 @@ do ->
           FileUploadService.uploadProof(file, fakeListing, opts)
           expect(proofDocument.loading).toEqual(true)
 
-          describe 'when the rentBurdenType option is not present', ->
-            it 'calls Service._processProofFile with the correct non-rent-burdened params', ->
-              uploadedFileParams =
-                session_uid: FileUploadService.session_uid()
-                listing_id: fakeListing.Id
-                listing_preference_id: listingPreferenceID
-                document_type: proofDocument.proofOption
-              FileUploadService.uploadProof(file, fakeListing, opts)
-              expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, proofDocument, uploadedFileParams)
+        describe 'when the rentBurdenType option is not present', ->
+          it 'calls Service._processProofFile with the correct non-rent-burdened params', ->
+            uploadedFileParams =
+              session_uid: FileUploadService.session_uid()
+              listing_id: fakeListing.Id
+              listing_preference_id: listingPreferenceID
+              document_type: proofDocument.proofOption
+            FileUploadService.uploadProof(file, fakeListing, opts)
+            expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, proofDocument, uploadedFileParams)
 
-          describe 'when the rentBurdenType option is present', ->
-            it 'calls Service._processProofFile with the correct rent burdened params', ->
+        describe 'when the rentBurdenType option is present', ->
+          it 'calls Service._processProofFile with the correct rent burdened params', ->
               opts =
                 rentBurdenType: 'lease'
                 address: address1
@@ -201,6 +201,7 @@ do ->
 
               FileUploadService.uploadProof(file, fakeListing, opts)
               expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, proofDocument, uploadedFileParams)
+
         describe "when document is provided", ->
           it 'removes file for document without preference', ->
             fakeDocument.file = null

--- a/spec/javascripts/services/file_upload_service_spec.coffee
+++ b/spec/javascripts/services/file_upload_service_spec.coffee
@@ -20,10 +20,11 @@ do ->
       getPreference: jasmine.createSpy().and.returnValue(fakeListingPreference)
       getPreferenceById: jasmine.createSpy().and.returnValue(true)
     }
-    fakeDocument =
+    fakeDocumentTemplate =
       proofOption: 'Loan pre-approval'
       file:
         name: "filename.png"
+    fakeDocument = null
     fakeShortFormApplicationService =
       preferences:
         documents:
@@ -66,61 +67,60 @@ do ->
         expect(FileUploadService.session_uid).not.toEqual null
 
     describe 'Service.deleteFile', ->
+      beforeEach ->
+        fakeDocument = angular.copy(fakeDocumentTemplate)
+        FileUploadService._proofDocument = jasmine.createSpy()
+          .and.returnValue(fakeDocument)
+        FileUploadService._uploadedFileParams = jasmine.createSpy()
+          .and.returnValue({uploaded_file: {id: 1}})
+        stubAngularAjaxRequest httpBackend, '/api/v1/short-form/proof', success
+
       afterEach ->
         httpBackend.verifyNoOutstandingExpectation()
         httpBackend.verifyNoOutstandingRequest()
 
       describe 'when opts.rentBurdenType is present', ->
-        it 'calls RentBurdenFileService.clearRentBurdenFile with the opts and Service.preferences', ->
-          stubAngularAjaxRequest httpBackend, '/api/v1/short-form/proof', success
+        it 'clears the file from Service.preferences\'s rent burden files', ->
           opts =
-            prefType: prefType
             rentBurdenType: 'lease'
-          FileUploadService.preferences.documents[prefType].file = file
-          FileUploadService._proofDocument = jasmine.createSpy()
-            .and.returnValue(FileUploadService.preferences.documents[prefType])
           FileUploadService.deleteFile(fakeListing, opts)
           httpBackend.flush()
-          expect(fakeRentBurdenFileService.clearRentBurdenFile)
-            .toHaveBeenCalledWith(
-              opts,
-              FileUploadService.preferences
-            )
+          expect(fakeRentBurdenFileService.clearRentBurdenFile).toHaveBeenCalledWith(
+            opts,
+            FileUploadService.preferences
+          )
 
       describe 'when opts.rentBurdenType is not present', ->
-        it 'sets the file property of the proof document to null', ->
-          stubAngularAjaxRequest httpBackend, '/api/v1/short-form/proof', success
-          opts =
-            prefType: prefType
-          FileUploadService.preferences.documents[prefType].file = file
+        beforeEach ->
+          opts = {}
           FileUploadService.deleteFile(fakeListing, opts)
           httpBackend.flush()
-          expect(FileUploadService.preferences.documents[prefType].file).toEqual null
 
-        it 'removes file for document without preference', ->
-          stubAngularAjaxRequest httpBackend, '/api/v1/short-form/proof', success
-          opts =
-            document: fakeDocument
-          FileUploadService.deleteFile(fakeListing, opts)
-          httpBackend.flush()
+        it 'removes the file from the document', ->
           expect(fakeDocument.file).toEqual null
+
+        it 'removes the proofOption from the document', ->
+          expect(fakeDocument.proofOption).toEqual null
 
     describe 'Service.uploadProof', ->
       beforeEach ->
-        proofDocument = FileUploadService.preferences.documents[prefType]
-        # FileUploadService._proofDocument = jasmine.createSpy().and.returnValue(proofDocument)
+        fakeDocument = angular.copy(fakeDocumentTemplate)
+        file = angular.copy(fileValue)
+        FileUploadService._proofDocument = jasmine.createSpy().and.returnValue(fakeDocument)
         FileUploadService._processProofFile = jasmine.createSpy()
+        FileUploadService._uploadedFileParams = jasmine.createSpy()
+          .and.returnValue({uploaded_file: {id: 1}})
         opts =
           prefType: prefType
 
-      describe 'when preference is not found on the listing', ->
-        beforeEach ->
-          fakeListingPreferenceService.getPreferenceById = jasmine.createSpy().and.returnValue(null)
-
+      describe 'when file is empty', ->
         afterEach ->
-          fakeListingPreferenceService.getPreferenceById = jasmine.createSpy().and.returnValue(listingPreferenceID)
+          errorMsg = undefined
 
         it 'returns a rejection', ->
+          file = null
+          errorMsg = 'ERROR.FILE_MISSING'
+
           rejection = FileUploadService.uploadProof(file, fakeListing, opts)
 
           promiseResult = null
@@ -130,25 +130,13 @@ do ->
             -> promiseResult = 'error'
           )
           deferred.resolve(rejection)
-          # please see https://docs.angularjs.org/api/ng/service/$q#testing
-          # to understand why the below line is required
           $rootScope.$apply()
 
           expect(promiseResult).toEqual('error')
 
-      describe 'when file is empty', ->
-        beforeEach ->
-          file = null
-          errorMsg = 'ERROR.FILE_MISSING'
-          opts =
-            prefType: prefType
-
-        afterEach ->
-          file = fileValue
-          errorMsg = undefined
-          FileUploadService.preferences = fakeShortFormApplicationService.preferences
-
+      describe 'when proof document is not found', ->
         it 'returns a rejection', ->
+          FileUploadService._proofDocument.and.returnValue(null)
           rejection = FileUploadService.uploadProof(file, fakeListing, opts)
 
           promiseResult = null
@@ -163,58 +151,34 @@ do ->
           expect(promiseResult).toEqual('error')
 
       describe 'when file is present', ->
-        beforeEach ->
-          file = fileValue
-          opts =
-            prefType: prefType
-
         it "sets the proof document's loading to true", ->
           FileUploadService.uploadProof(file, fakeListing, opts)
-          expect(proofDocument.loading).toEqual(true)
+          expect(fakeDocument.loading).toEqual(true)
 
         describe 'when the rentBurdenType option is not present', ->
           it 'calls Service._processProofFile with the correct non-rent-burdened params', ->
-            uploadedFileParams =
-              session_uid: FileUploadService.session_uid()
-              listing_id: fakeListing.Id
-              listing_preference_id: listingPreferenceID
-              document_type: proofDocument.proofOption
+            uploadedFileParams = {uploaded_file: {id: 2}}
+            FileUploadService._uploadedFileParams.and.returnValue(uploadedFileParams)
             FileUploadService.uploadProof(file, fakeListing, opts)
-            expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, proofDocument, uploadedFileParams)
+            expect(FileUploadService._processProofFile).toHaveBeenCalledWith(
+              file,
+              fakeDocument,
+              uploadedFileParams.uploaded_file
+            )
 
         describe 'when the rentBurdenType option is present', ->
           it 'calls Service._processProofFile with the correct rent burdened params', ->
-              opts =
-                rentBurdenType: 'lease'
-                address: address1
-                index: 1
-                prefType: prefType
-
-              uploadedFileParams =
-                session_uid: FileUploadService.session_uid()
-                listing_id: fakeListing.Id
-                listing_preference_id: listingPreferenceID
-                document_type: proofDocument.proofOption
-                address: opts.address
-                rent_burden_type: opts.rentBurdenType
-                rent_burden_index: opts.index
-
-              FileUploadService.uploadProof(file, fakeListing, opts)
-              expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, proofDocument, uploadedFileParams)
-
-        describe "when document is provided", ->
-          it 'removes file for document without preference', ->
-            fakeDocument.file = null
-            fakeDocument.loading = true
             opts =
-              document: fakeDocument
-            uploadedFileParams =
-              session_uid: FileUploadService.session_uid()
-              listing_id: fakeListing.Id
-              listing_preference_id: undefined
-              document_type: fakeDocument.proofOption
+              rentBurdenType: 'lease'
+            uploadedFileParams = {uploaded_file: {id: 3}}
+            FileUploadService._uploadedFileParams.and.returnValue(uploadedFileParams)
+
             FileUploadService.uploadProof(file, fakeListing, opts)
-            expect(FileUploadService._processProofFile).toHaveBeenCalledWith(file, fakeDocument, uploadedFileParams)
+            expect(FileUploadService._processProofFile).toHaveBeenCalledWith(
+              file,
+              fakeDocument,
+              uploadedFileParams.uploaded_file
+            )
 
     describe 'Service._proofDocument', ->
       beforeEach ->

--- a/spec/javascripts/services/income_calculator_service_spec.coffee
+++ b/spec/javascripts/services/income_calculator_service_spec.coffee
@@ -54,12 +54,14 @@ do ->
 
     describe 'Service.calculateTotalYearlyIncome', ->
       it 'correctly adds up total yearly income from incomeSources', ->
-        fakeIncomeSource2 =
-          source: "Disability"
-          value: "175"
-          frequency: "month"
-          editing: false
-        expectedResult = fakeIncomeSource.value + (fakeIncomeSource2.value * 12)
-        IncomeCalculatorService.addIncomeSource(fakeIncomeSource)
-        IncomeCalculatorService.addIncomeSource(fakeIncomeSource2)
-        expect(IncomeCalculatorService.calculateTotalYearlyIncome()).toEqual expectedResult
+        fakeYearlyIncomeSource =
+          value: 10000
+          frequency: 'year'
+        fakeMonthlyIncomeSource =
+          value: 175
+          frequency: 'month'
+        expectedTotalIncome = fakeYearlyIncomeSource.value + (fakeMonthlyIncomeSource.value * 12)
+
+        IncomeCalculatorService.incomeSources = [fakeYearlyIncomeSource, fakeMonthlyIncomeSource]
+        spyOn(IncomeCalculatorService, '_parseIncomeValue').and.returnValues(10000.0, 175.0)
+        expect(IncomeCalculatorService.calculateTotalYearlyIncome()).toEqual expectedTotalIncome

--- a/spec/javascripts/services/listing_data_service_spec.coffee
+++ b/spec/javascripts/services/listing_data_service_spec.coffee
@@ -125,18 +125,21 @@ do ->
         spyOn(fakeListingEligibilityService, 'hasEligibilityFilters').and.returnValue(true)
         ListingDataService.getListings({checkEligibility: true, params: {Tenure: 'rental'}})
         expect(ListingDataService.getListingsWithEligibility).toHaveBeenCalled()
+
       it 'calls ListingEligibilityService.eligibilityYearlyIncome', ->
         spyOn(fakeListingEligibilityService, 'hasEligibilityFilters').and.returnValue(true)
         ListingDataService.getListings({checkEligibility: true, params: {Tenure: 'rental'}})
         expect(fakeListingEligibilityService.eligibilityYearlyIncome).toHaveBeenCalled()
+
       it 'passes params to http request', ->
         fakeParams = {checkEligibility: false, params: {Tenure: 'rental'}}
         httpBackend.expect('GET', "/api/v1/listings.json?Tenure=rental").respond(fakeListings)
         spyOn(fakeListingEligibilityService, 'hasEligibilityFilters').and.returnValue(false)
         ListingDataService.getListings(fakeParams)
-        httpBackend.flush()
+        expect(httpBackend.flush).not.toThrow()
         httpBackend.verifyNoOutstandingExpectation()
         httpBackend.verifyNoOutstandingRequest()
+
       it 'cleans filters', ->
         ListingDataService.getListings({checkEligibility: false, clearFilters: true})
         expect(fakeListingEligibilityService.resetEligibilityFilters).toHaveBeenCalled()

--- a/spec/javascripts/services/listing_lottery_service_spec.coffee
+++ b/spec/javascripts/services/listing_lottery_service_spec.coffee
@@ -91,14 +91,16 @@ do ->
         spyOn(ListingLotteryService, 'lotteryDatePassed').and.returnValue(true)
         expect(ListingLotteryService.lotteryIsUpcoming(fakeListing)).toEqual false
 
-      it 'returns true when the listing has no results and lottery date has not passed', ->
+      it 'returns true when the listing has no results, the lottery date has not passed, and the lottery is not complete', ->
         fakeListing.Lottery_Results = false
         spyOn(ListingLotteryService, 'lotteryDatePassed').and.returnValue(false)
+        spyOn(ListingLotteryService, 'lotteryComplete').and.returnValue(false)
         expect(ListingLotteryService.lotteryIsUpcoming(fakeListing)).toEqual true
 
       it 'returns true when the listings lottery is not complete', ->
-        fakeListing.Lottery_Status = 'Not Yet Run'
+        fakeListing.Lottery_Results = false
         spyOn(ListingLotteryService, 'lotteryDatePassed').and.returnValue(false)
+        spyOn(ListingLotteryService, 'lotteryComplete').and.returnValue(false)
         expect(ListingLotteryService.lotteryIsUpcoming(fakeListing)).toEqual true
 
       it 'returns false when the listings lottery is complete', ->

--- a/spec/javascripts/services/listing_preference_service_spec.coffee
+++ b/spec/javascripts/services/listing_preference_service_spec.coffee
@@ -41,7 +41,7 @@ do ->
     )
 
     describe 'Service.getListingPreferences', ->
-      beforeEach ->
+      beforeEach (done) ->
         # have to populate listing first
         listing = angular.copy(fakeListing)
         listing.Id = 'fakeId-123'
@@ -50,6 +50,7 @@ do ->
         preferences.preferences = preferences.preferences.concat fakeCustomPrefs
         stubAngularAjaxRequest httpBackend, "/api/v1/listings/#{listing.Id}/preferences", preferences
         ListingPreferenceService.getListingPreferences(listing)
+        done()
 
       afterEach ->
         httpBackend.verifyNoOutstandingExpectation()

--- a/spec/javascripts/services/short_form_navigation_service_spec.coffee
+++ b/spec/javascripts/services/short_form_navigation_service_spec.coffee
@@ -103,6 +103,7 @@ do ->
         expect(page).toEqual 'preferences-intro'
 
       it 'gets review survey if survey is incomplete', ->
+        fakeShortFormApplicationService.application.surveyComplete = false
         page = ShortFormNavigationService.getStartOfSection({name: 'Review'})
         expect(page).toEqual 'review-optional'
 

--- a/spec/javascripts/services/short_form_navigation_service_spec.coffee
+++ b/spec/javascripts/services/short_form_navigation_service_spec.coffee
@@ -77,6 +77,7 @@ do ->
 
       it 'gets household intro page if no householdMembers', ->
         householdSection = ShortFormNavigationService.sections()[2]
+        fakeShortFormApplicationService.application.householdMembers = []
         page = ShortFormNavigationService.getStartOfSection(householdSection)
         expect(page).toEqual 'household-intro'
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165609939

In Jasmine 3, it is now the default to run tests in random order. Previously, we were not running tests in random order. Running them randomly has exposed many tests where the test setup was not isolated enough and so the test failed if certain other tests were run before. In this story, we'll be fixing all those newly failing tests after the Jasmine upgrade.