### PR TITLE
[Hotfix] Fix sref syntax in spanish/chinese income calculator link #167072982  

### DIFF
--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -759,7 +759,7 @@
         "HEADER": {
             "FIND_MATCHING_LISTINGS": "Encuentre anuncios compatibles",
             "IF_YOU_TELL_US": "Si nos informa el tamaño y los ingresos del grupo familiar, podemos destacar los anuncios de vivienda para los que sería elegible.",
-            "OR_GET_HELP_CALCULATING_INCOME": "u <a ui-sref=\"{{sref}}\">obtenga ayuda para calcular sus ingresos</a>"
+            "OR_GET_HELP_CALCULATING_INCOME": "u <a ui-sref='{{sref}}'>obtenga ayuda para calcular sus ingresos</a>"
         }
     },
     "LISTINGS_FOR_SALE": {

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -759,7 +759,7 @@
         "HEADER": {
             "FIND_MATCHING_LISTINGS": "尋找符合的名單",
             "IF_YOU_TELL_US": "如果您告知家庭人數以及收入，我們可以將您可能符合資格的清單標亮顯示。",
-            "OR_GET_HELP_CALCULATING_INCOME": "或是<a ui-sref=\"{{sref}}\">獲得收入計算協助</a>"
+            "OR_GET_HELP_CALCULATING_INCOME": "或是<a ui-sref='{{sref}}'>獲得收入計算協助</a>"
         }
     },
     "LISTINGS_FOR_SALE": {


### PR DESCRIPTION
Replace escaped double quotes with single quotes to match english

https://www.pivotaltracker.com/story/show/167072982