### PR TITLE
[Hotfix] fix submission email translation missing bug #166430058

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,3 +1,20 @@
 es:
   hello: "Hola %{name}"
   thank_you: "Gracias"
+  email_signature: "The San Francisco Mayor's Office of Housing and Community Development"
+
+  emailer:
+    submission_confirmation:
+      thanks_for_applying_to_listing: "Thanks for applying. We have received your application for %{link}."
+      here_is_your_lottery_number: "Here is your lottery number: %{lottery_number}"
+      what_to_expect_next: "What to expect next"
+      lottery_will_be_held: "The lottery will be held on %{lottery_date}. Housing lottery results will be posted %{link}."
+      on_the_listing: "on the listing"
+      applicants_will_be_contacted: "Applicants will be contacted by the agent in lottery rank order until vacancies are filled."
+      should_your_application_be_chosen_sale: "Should your application be chosen, be prepared to fill out a more detailed application and provide %{link} within 5 business days of being contacted."
+      required_supporting_documents: "required supporting documents"
+      should_your_application_be_chosen_rental: "Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents within 5 business days of being contacted."
+      see_below_for_contact_information: "If you need to update information on your application, do not apply again or both applications will be removed from the lottery. Contact the agent. See below for contact information for the Agent for this listing."
+      how_are_we_doing: "How are we doing?"
+      we_would_like_your_feedback: "We'd like to get your feedback"
+      office_hours: "Office Hours"

--- a/config/locales/tl.yml
+++ b/config/locales/tl.yml
@@ -1,1 +1,20 @@
 tl:
+  hello: "Hello %{name}"
+  thank_you: "Thank you"
+  email_signature: "The San Francisco Mayor's Office of Housing and Community Development"
+
+  emailer:
+    submission_confirmation:
+      thanks_for_applying_to_listing: "Thanks for applying. We have received your application for %{link}."
+      here_is_your_lottery_number: "Here is your lottery number: %{lottery_number}"
+      what_to_expect_next: "What to expect next"
+      lottery_will_be_held: "The lottery will be held on %{lottery_date}. Housing lottery results will be posted %{link}."
+      on_the_listing: "on the listing"
+      applicants_will_be_contacted: "Applicants will be contacted by the agent in lottery rank order until vacancies are filled."
+      should_your_application_be_chosen_sale: "Should your application be chosen, be prepared to fill out a more detailed application and provide %{link} within 5 business days of being contacted."
+      required_supporting_documents: "required supporting documents"
+      should_your_application_be_chosen_rental: "Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents within 5 business days of being contacted."
+      see_below_for_contact_information: "If you need to update information on your application, do not apply again or both applications will be removed from the lottery. Contact the agent. See below for contact information for the Agent for this listing."
+      how_are_we_doing: "How are we doing?"
+      we_would_like_your_feedback: "We'd like to get your feedback"
+      office_hours: "Office Hours"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,1 +1,20 @@
 zh:
+  hello: "Hello %{name}"
+  thank_you: "Thank you"
+  email_signature: "The San Francisco Mayor's Office of Housing and Community Development"
+
+  emailer:
+    submission_confirmation:
+      thanks_for_applying_to_listing: "Thanks for applying. We have received your application for %{link}."
+      here_is_your_lottery_number: "Here is your lottery number: %{lottery_number}"
+      what_to_expect_next: "What to expect next"
+      lottery_will_be_held: "The lottery will be held on %{lottery_date}. Housing lottery results will be posted %{link}."
+      on_the_listing: "on the listing"
+      applicants_will_be_contacted: "Applicants will be contacted by the agent in lottery rank order until vacancies are filled."
+      should_your_application_be_chosen_sale: "Should your application be chosen, be prepared to fill out a more detailed application and provide %{link} within 5 business days of being contacted."
+      required_supporting_documents: "required supporting documents"
+      should_your_application_be_chosen_rental: "Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents within 5 business days of being contacted."
+      see_below_for_contact_information: "If you need to update information on your application, do not apply again or both applications will be removed from the lottery. Contact the agent. See below for contact information for the Agent for this listing."
+      how_are_we_doing: "How are we doing?"
+      we_would_like_your_feedback: "We'd like to get your feedback"
+      office_hours: "Office Hours"


### PR DESCRIPTION
Part of https://www.pivotaltracker.com/story/show/166430058

Issue was:  
Spanish emails were showing up as just the translation keys because translations were missing from locale files.

> Hola Andrea Egan,
> Thanks For Applying To Listing
> Here Is Your Lottery Number
> What To Expect Next:
> Lottery Will Be Held Applicants Will Be Contacted
> Should Your Application Be Chosen Rental
> See Below For Contact Information
> Larry Agent
> Sales Agent
> (415) 555-5555
> larry.livingston@sfgov.org
> Office Hours:
> How Are We Doing We Would Like Your Feedback.
> Gracias,
> Email Signature
>


This PR just copies that english over so e.g. spanish applicants get their lottery number and the lottery date. 