### PR TITLE
Application start image overlaps app date flag #170682920

### DIFF
--- a/app/assets/javascripts/short-form/templates/a1-intro.html.slim
+++ b/app/assets/javascripts/short-form/templates/a1-intro.html.slim
@@ -1,22 +1,27 @@
 section.app-container
   .row.collapse
-    .medium-8.medium-centered.columns.fixed-width
+    .medium-8.medium-centered.columns.fixed-width.margin-bottom
       h2.t-gamma.text-center.margin-top.padding-left--2x.padding-right--2x
         | {{'a1_intro.title' | translate}}
       form.app-card.form-card.focus-container
-        h1.property-card_title.text-center.margin-bottom.hide-for-medium-up.skiptranslate
+        h1.property-card_title.text-center.hide-for-medium-up.skiptranslate
           | {{listing.Name}}
-        figure.property-card_figure.radius
-          .property-card_overlay
-            img.property-card_thumb alt="Listing Name: {{listing.Name}}" ng-src="{{listing.imageURL}}"
-            span.application-label.label.label--flag.primary
-              ' {{'t.application_due' | translate}}
-              | {{listing.Application_Due_Date | date : "MMM d, yyyy 'at' ha" }}
-          figcaption.property-card_info.skiptranslate
-            h1.property-card_title.show-for-medium-up
-              | {{listing.Name}}
-            p.property-card_address
-              | {{formattedBuildingAddress(listing)}}
+        p.property-card_address.text-center.hide-for-medium-up.skiptranslate
+          | {{formattedBuildingAddress(listing)}}
+        .property-card_figure-wrapper
+          figure.property-card_figure
+            .property-card_overlay
+              img.property-card_thumb alt="Listing Name: {{listing.Name}}" ng-src="{{listing.imageURL}}"
+            figcaption.property-card_info.skiptranslate
+              h1.property-card_title.show-for-medium-up
+                | {{listing.Name}}
+              p.property-card_address.show-for-medium-up
+                | {{formattedBuildingAddress(listing)}}
+
+          span.application-label.label.label--flag.primary
+                ' {{'t.application_due' | translate}}
+                | {{listing.Application_Due_Date | date : "MMM d, yyyy 'at' ha" }}
+
     .text-center.padding ng-class="{'margin-top--2x': application.applicationLanguage == 'English'}"
       h3.h-caps.t-base.d-block ng-if="application.applicationLanguage == 'English'"
         | {{'a1_intro.choose_your_language' | translate}}


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/170682920 where, on the application start screen, the image overlaps the application date flag.

- Adds wrapper div around figure element
- Adds viewport-dependent visibility classes