### PR TITLE
Chores/fix flickering e2e tests #163066582

### DIFF
--- a/spec/e2e/conf.js
+++ b/spec/e2e/conf.js
@@ -3,6 +3,8 @@ var config = require('./conf-shared')
 config.baseUrl = 'http://localhost:3000/'
 config.capabilities = {
   browserName: 'chrome',
+  getPageTimeout: 30000,
+  allScriptsTimeout: 60000,
   chromeOptions: {
     // tall, skinny window. trying to avoid errors where it says button is not visible/clickable
      args: [ '--window-size=800,1200' ]

--- a/spec/e2e/pages/angular-page.coffee
+++ b/spec/e2e/pages/angular-page.coffee
@@ -24,6 +24,7 @@ class AngularPage
 
   checkCheckbox: (checkboxId, callback) ->
     checkbox = element(By.id(checkboxId))
+    browser.wait(EC.presenceOf(checkbox), 5000)
     checkbox.isSelected().then (selected) ->
       checkbox.click() unless selected
       callback() if callback

--- a/spec/e2e/step_definitions/short-form/preferences_steps.coffee
+++ b/spec/e2e/step_definitions/short-form/preferences_steps.coffee
@@ -227,6 +227,8 @@ When 'I click the Live or Work in SF checkbox', ->
   Utils.Page.checkCheckbox('preferences-liveWorkInSf')
 
 When 'I open the Live or Work in SF dropdown', ->
+  viewApp = element(By.id('liveWorkPrefOption'))
+  browser.wait(EC.presenceOf(viewApp), 5000)
   Utils.Page.checkCheckbox('liveWorkPrefOption')
 
 When 'I select the Live in SF preference', ->

--- a/spec/e2e/step_definitions/short-form/review_steps.coffee
+++ b/spec/e2e/step_definitions/short-form/review_steps.coffee
@@ -1,5 +1,6 @@
 Utils = require('../../utils')
 Pages = require('../../pages/short-form').Pages
+EC = protractor.ExpectedConditions
 { When, Then } = require('cucumber')
 
 When 'I fill out the optional survey', ->
@@ -14,6 +15,7 @@ When 'I agree to the terms and submit', ->
 
 When 'I click to view submitted application', ->
   viewApp = element(By.id('view-app'))
+  browser.wait(EC.presenceOf(viewApp), 5000)
   Utils.Page.scrollToElement(viewApp).then ->
     viewApp.click()
 

--- a/spec/e2e/utils/page-util.coffee
+++ b/spec/e2e/utils/page-util.coffee
@@ -1,4 +1,5 @@
 remote = require('selenium-webdriver/remote')
+EC = protractor.ExpectedConditions
 
 PageUtil = {
   testListingId: 'a0W0P00000F8YG4UAN'
@@ -6,6 +7,7 @@ PageUtil = {
   saleListingId: process.env.TEST_SALE_LISTING_ID || 'a0W0P00000GlKfBUAV'
   checkCheckbox: (checkboxId, callback) ->
     checkbox = element(By.id(checkboxId))
+    browser.wait(EC.presenceOf(checkbox), 5000)
     checkbox.isSelected().then (selected) ->
       checkbox.click() unless selected
       callback() if callback


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163066582

Approach that made a huge difference for all of the flickering tests was waiting for the element to appear before :

```
EC = protractor.ExpectedConditions
elem = element(SELECTORHERE)
browser.wait(EC.presenceOf(elem), 5000)
```

I also increased the timeout universally on `conf.js`

For future tests, we get to apply this if there is a pattern of it flickering.

Tests passed cleanly several times locally and semaphore had a clean pass right at the first attempt! 