### PR TITLE
Hotfix - Allow links in alert message

### DIFF
--- a/app/assets/javascripts/shared/templates/alert-message.html.slim
+++ b/app/assets/javascripts/shared/templates/alert-message.html.slim
@@ -5,5 +5,4 @@
         span.ui-icon.ui-medium.i-white
           svg
             use xlink:href="#i-warning"
-        p.offset-icon.c-white.t-small.t-semi
-          | {{ alertMessage }}
+        p.offset-icon.c-white.t-small.t-semi ng-bind-html="alertMessage"

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,3 +26,9 @@ body .goog-te-banner-frame {
 #google_translate_element {
   display: none;
 }
+
+
+.banner-bar a {
+  text-decoration: underline;
+  color: inherit
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -30,5 +30,6 @@ body .goog-te-banner-frame {
 
 .banner-bar a {
   text-decoration: underline;
-  color: inherit
+  color: inherit;
+  font-weight: 700;
 }


### PR DESCRIPTION
This PR allows for links in the alert message so we can link out to a MOHCD page for more information about changes to the affordable housing application 

![image](https://user-images.githubusercontent.com/11825994/76641170-6401ab80-650e-11ea-98f7-48ef4440908a.png)


My main concern for this is that we could be opening ourselves up to some sort of vulnerability just allowing any html content from an env var, but I think that we're pretty safe

Review instructions:
1. Go to the heroku page for the review app, update the config settings to add a sample message with a link with the name ALERT_MESSAGE, e.g. `"Test some text and a link and that's about all <a href='https://google.com'> test link</a>"`
1. Go to the [review app](https://dahlia-full-hotfixes-al-h4xbaj.herokuapp.com/), and verify that the alert message shows up as expected and the link works. 
